### PR TITLE
Add files via upload

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -835,17 +835,23 @@ TreeItem *TreeItem::_get_prev_in_tree(bool p_wrap, bool p_include_invisible) {
 
 	if (!prev_item) {
 		current = current->parent;
-		if (current == tree->root && tree->hide_root) {
-			return nullptr;
-		} else if (!current) {
-			if (p_wrap) {
+		if(p_wrap)
+		{
+			if ((current == tree->root && tree->hide_root) || !current)
+			{
 				current = this;
 				TreeItem *temp = this->get_next_visible();
-				while (temp) {
+				while (temp)
+				{
 					current = temp;
 					temp = temp->get_next_visible();
 				}
-			} else {
+			}
+		}
+		else
+		{
+			if((current == tree->root && tree->hide_root) || !current)
+			{
 				return nullptr;
 			}
 		}


### PR DESCRIPTION
fixes #85032
 TreeItem.get_prev_visible and TreeItem.get_prev_in_tree don't return null anymore when setting wrap to true

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
