### PR TITLE
editor changes

### DIFF
--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -117,6 +117,10 @@ void CSGBrush::copy_from(const CSGBrush &p_brush, const Transform3D &p_xform) {
 }
 
 void CSGBrush::add_ngons(const Vector<int> &p_ngons) {
+	if (p_ngons.size() > faces.size()) {
+		ERR_PRINT("Wrong number of elements in p_ngons");
+		return;
+	}
 	ngons = p_ngons;
 	for (int i = 0; i < p_ngons.size(); i++) {
 		if (p_ngons[i] > num_ngons) {

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -115,3 +115,33 @@ void CSGBrush::copy_from(const CSGBrush &p_brush, const Transform3D &p_xform) {
 
 	_regen_face_aabbs();
 }
+
+void CSGBrush::add_ngons(const Vector<int> &p_ngons) {
+	ngons = p_ngons;
+	for (int i = 0; i < p_ngons.size(); i++) {
+		if (p_ngons[i] > num_ngons) {
+			num_ngons++;
+		}
+	}
+}
+
+Vector<int> CSGBrush::get_ngon_faces(int p_ngon) {
+	if (p_face > num_ngons) {
+		ERR_PRINT("Invalid ngon id");
+		return nullptr;
+	}
+
+	if (num_ngons == 0) {
+		ERR_PRINT("Ngons not set in CSGBrush");
+		return nullptr;
+	}
+
+	Vector<int> ret;
+
+	for (int i = 0; i < ngons.size(); i++) {
+		if (ngons[i] == p_face) {
+			ret.push_back(i);
+		}
+	}
+	return ret;
+}

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -122,17 +122,21 @@ void CSGBrush::add_ngons(const Vector<int> &p_ngons) {
 		return;
 	}
 	ngons = p_ngons;
-	for (int i = 0; i < p_ngons.size(); i++) {
-		if (p_ngons[i] > num_ngons) {
+	for (int i = 0; i < ngons.size(); i++) {
+		if (ngons[i] > num_ngons) {
 			num_ngons++;
 		}
+	}
+
+	if (ngons.size() > 0) {
+		num_ngons++;
 	}
 }
 
 Vector<int> CSGBrush::get_ngon_faces(int p_ngon) {
 	Vector<int> ret;
 
-	if (p_ngon > num_ngons) {
+	if (p_ngon >= num_ngons) {
 		ERR_PRINT("Invalid ngon id");
 		return ret;
 	}

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -32,7 +32,7 @@
 
 // CSGBrush
 
-void CSGBrush::build_from_faces(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials, const Vector<bool> &p_flip_faces) {
+void CSGBrush::build_from_faces(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs, const Vector<int> &p_smooth, const Vector<Ref<Material>> &p_materials, const Vector<bool> &p_flip_faces) {
 	faces.clear();
 
 	int vc = p_vertices.size();
@@ -43,7 +43,7 @@ void CSGBrush::build_from_faces(const Vector<Vector3> &p_vertices, const Vector<
 	int uvc = p_uvs.size();
 	const Vector2 *ruv = p_uvs.ptr();
 	int sc = p_smooth.size();
-	const bool *rs = p_smooth.ptr();
+	const int *rs = p_smooth.ptr();
 	int mc = p_materials.size();
 	const Ref<Material> *rm = p_materials.ptr();
 	int ic = p_flip_faces.size();
@@ -68,7 +68,7 @@ void CSGBrush::build_from_faces(const Vector<Vector3> &p_vertices, const Vector<
 		if (sc == vc / 3) {
 			f.smooth = rs[i];
 		} else {
-			f.smooth = false;
+			f.smooth = 0;
 		}
 
 		if (ic == vc / 3) {

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -126,20 +126,20 @@ void CSGBrush::add_ngons(const Vector<int> &p_ngons) {
 }
 
 Vector<int> CSGBrush::get_ngon_faces(int p_ngon) {
-	if (p_face > num_ngons) {
+	Vector<int> ret;
+
+	if (p_ngon > num_ngons) {
 		ERR_PRINT("Invalid ngon id");
-		return nullptr;
+		return ret;
 	}
 
 	if (num_ngons == 0) {
 		ERR_PRINT("Ngons not set in CSGBrush");
-		return nullptr;
+		return ret;
 	}
 
-	Vector<int> ret;
-
 	for (int i = 0; i < ngons.size(); i++) {
-		if (ngons[i] == p_face) {
+		if (ngons[i] == p_ngon) {
 			ret.push_back(i);
 		}
 	}

--- a/modules/csg/csg.h
+++ b/modules/csg/csg.h
@@ -50,6 +50,8 @@ struct CSGBrush {
 
 	Vector<Face> faces;
 	Vector<Ref<Material>> materials;
+	Vector<int> ngons;
+	int num_ngons = 0;
 
 	inline void _regen_face_aabbs() {
 		for (int i = 0; i < faces.size(); i++) {
@@ -63,4 +65,6 @@ struct CSGBrush {
 	// Create a brush from faces.
 	void build_from_faces(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials, const Vector<bool> &p_invert_faces);
 	void copy_from(const CSGBrush &p_brush, const Transform3D &p_xform);
+	void add_ngons(const Vector<int> &p_ngons);
+	Vector<int> get_ngon_faces(int p_ngon);
 };

--- a/modules/csg/csg.h
+++ b/modules/csg/csg.h
@@ -43,7 +43,7 @@ struct CSGBrush {
 		Vector3 vertices[3];
 		Vector2 uvs[3];
 		AABB aabb;
-		bool smooth = false;
+		int smooth = 0;
 		bool invert = false;
 		int material = 0;
 	};
@@ -63,7 +63,7 @@ struct CSGBrush {
 	}
 
 	// Create a brush from faces.
-	void build_from_faces(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials, const Vector<bool> &p_invert_faces);
+	void build_from_faces(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs, const Vector<int> &p_smooth, const Vector<Ref<Material>> &p_materials, const Vector<bool> &p_invert_faces);
 	void copy_from(const CSGBrush &p_brush, const Transform3D &p_xform);
 	void add_ngons(const Vector<int> &p_ngons);
 	Vector<int> get_ngon_faces(int p_ngon);

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2509,7 +2509,7 @@ bool CSGBox3D::_set(const StringName &p_name, const Variant &p_value) {
 
 void CSGBox3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	set_face_material(get_all_csg_faces(), material)
+	set_face_material(get_all_csg_faces(), material);
 	update_gizmos();
 }
 
@@ -2741,7 +2741,7 @@ bool CSGCylinder3D::get_smooth_faces() const {
 
 void CSGCylinder3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	set_face_material(get_all_csg_faces(), material)
+	set_face_material(get_all_csg_faces(), material);
 }
 
 Ref<Material> CSGCylinder3D::get_material() const {
@@ -2968,7 +2968,7 @@ bool CSGTorus3D::get_smooth_faces() const {
 
 void CSGTorus3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	set_face_material(get_all_csg_faces(), material)
+	set_face_material(get_all_csg_faces(), material);
 }
 
 Ref<Material> CSGTorus3D::get_material() const {
@@ -3628,7 +3628,7 @@ bool CSGPolygon3D::get_smooth_faces() const {
 
 void CSGPolygon3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	set_face_material(get_all_csg_faces(), material)
+	set_face_material(get_all_csg_faces(), material);
 }
 
 Ref<Material> CSGPolygon3D::get_material() const {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1425,7 +1425,7 @@ bool CSGShape3D::resize_brush(const Vector3 &prev_size, const Vector3 &p_size) {
 	return true;
 }
 
-void set_csg_flat(bool p_mode) {
+void CSGShape3D::set_csg_flat(bool p_mode) {
 	// This changes all faces so it can't be used with CSGCylinder3D.
 	CSGBrush *n = _get_brush();
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1843,7 +1843,7 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_smoothing_angle", "smoothing_angle"), &CSGShape3D::set_smoothing_angle);
 	ClassDB::bind_method(D_METHOD("get_smoothing_angle"), &CSGShape3D::get_smoothing_angle);
 
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_csg_brush", PROPERTY_HINT_NO_NODEPATH, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_csg_brush", "get_csg_brush");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_csg_brush", PROPERTY_HINT_NO_NODEPATH, "", PROPERTY_USAGE_NO_EDITOR), "set_csg_brush", "get_csg_brush");
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autosmooth"), "set_autosmooth", "is_autosmooth");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "smoothing_angle", PROPERTY_HINT_RANGE, "0,180,0.1,degrees"), "set_smoothing_angle", "get_smoothing_angle");

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1101,6 +1101,11 @@ void CSGShape3D::rebuild_brush() {
 	_make_dirty();
 }
 
+void CSGShape3D::brush_modified() {
+	// This is an interface to _make_painted() since set_csg_brush() doesn't call it and that causes issues with undo.
+	_make_painted();
+}
+
 Dictionary CSGShape3D::get_csg_brush() {
 	Dictionary p_brush_data;
 	p_brush_data["painted"] = painted;
@@ -1458,10 +1463,51 @@ void CSGShape3D::calculate_cube_map(const Vector<int> &p_faces) {
 			n->faces.write[p].uvs[2] = Vector2(mir_x * v3.x, v3.z);
 		} else {
 			// Direction Z, XY.
-			float mir_x = ang.normal.z < 0.0 ? -1.0 : 1.0;
+			float mir_x = ang.normal.z < 0.0 ? 1.0 : -1.0;
 			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(mir_x * v1.x, v1.y));
 			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(mir_x * v2.x, v2.y));
 			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(mir_x * v3.x, v3.y));
+		}
+	}
+	_make_painted(true);
+}
+
+void CSGShape3D::calculate_cylinder_map(const Vector<int> &p_faces) {
+	// Simple cylinder unwrapping.
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	// 3D goes bot to top while 2D goes top to bottom.
+	Transform2D p_rotation = Transform2D(Math::deg_to_rad(180.0), Vector2(0.0, 0.0));
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+
+		Vector3 v1 = n->faces[p].vertices[0];
+		Vector3 v2 = n->faces[p].vertices[1];
+		Vector3 v3 = n->faces[p].vertices[2];
+
+		Plane ang(v1, v2, v3);
+		Vector3 start_vec = Vector3(1.0, 0.0, 0.0);
+		if (Math::abs(ang.normal.y) > 0) {
+			// Top and bottom faces.
+			float mir_x = ang.normal.x < 0.0 ? -1.0 : 1.0;
+			n->faces.write[p].uvs[0] = Vector2(mir_x * v1.x, v1.z);
+			n->faces.write[p].uvs[1] = Vector2(mir_x * v2.x, v2.z);
+			n->faces.write[p].uvs[2] = Vector2(mir_x * v3.x, v3.z);
+		} else {
+			float shift_x = ang.normal.z < 0.0 ? -1.0 : 1.0;
+			Vector3 t_ang_1 = Vector3(v1.x, 0.0, v1.z).normalized();
+			Vector3 t_ang_2 = Vector3(v1.x, 0.0, v1.z).normalized();
+			Vector3 t_ang_3 = Vector3(v1.x, 0.0, v1.z).normalized();
+			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(shift_x * start_vec.dot(t_ang_1), v1.y));
+			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(shift_x * start_vec.dot(t_ang_2), v2.y));
+			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(shift_x * start_vec.dot(t_ang_3), v3.y));
 		}
 	}
 	_make_painted(true);
@@ -1841,7 +1887,7 @@ PackedStringArray CSGShape3D::get_configuration_warnings() const {
 	const CSGShape3D *current_shape = this;
 	while (current_shape) {
 		if (!current_shape->brush || current_shape->brush->faces.is_empty()) {
-			warnings.push_back(RTR("The CSGShape3D has an empty shape.\nCSGShape3D empty shapes typically occur because the mesh is not manifold.\nA manifold mesh forms a solid object without gaps, holes, or loose edges.\nEach edge must be a member of exactly two faces."));
+			warnings.push_back(RTR("The CSGShape3D has an empty shape.\nCSGShape3D empty shapes typically occur because the mesh is not manifold.\nA manifold mesh forms a solid object without gaps, holes, or loose edges.\nEach edge must be a member of exactly two faces.\nThis can also happen when using a CSGCombiner3D as child of another CSG node. CSGCombiner3D should only be used as the parent of other CSG nodes."));
 			break;
 		}
 		current_shape = current_shape->parent_shape;
@@ -1974,7 +2020,7 @@ CSGCombiner3D::CSGCombiner3D() {
 
 /////////////////////
 
-CSGBrush *CSGPrimitive3D::_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<int> &p_smooth, const Vector<Ref<Material>> &p_materials) {
+CSGBrush *CSGPrimitive3D::_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<int> &p_smooth, const Vector<Ref<Material>> &p_materials, const Vector<int> &ngons) {
 	CSGBrush *new_brush = memnew(CSGBrush);
 
 	Vector<bool> invert;
@@ -1987,27 +2033,6 @@ CSGBrush *CSGPrimitive3D::_create_brush_from_arrays(const Vector<Vector3> &p_ver
 		}
 	}
 	new_brush->build_from_faces(p_vertices, p_uv, p_smooth, p_materials, invert);
-
-	// Meshes are imported as triangles so there's no way to use quads from here.
-	Vector<int> ngons;
-	ngons.resize(new_brush->faces.size());
-	{
-		// Create perfect quads.
-		ERR_FAIL_COND_V(!(new_brush->faces.size() > 0), new_brush);
-		int ngon_counter = 0;
-		ngons.write[0] = ngon_counter;
-		Vector3 f_vert = new_brush->faces[0].vertices[0];
-		Vector3 l_vert = new_brush->faces[0].vertices[2];
-		for (int i = 1; i < ngons.size(); i++) {
-			if (!f_vert.is_equal_approx(new_brush->faces[i].vertices[2]) || !l_vert.is_equal_approx(new_brush->faces[i].vertices[0])) {
-				ngon_counter++;
-			}
-			ngons.write[i] = ngon_counter;
-			f_vert = new_brush->faces[i].vertices[0];
-			l_vert = new_brush->faces[i].vertices[2];
-		}
-	}
-
 	new_brush->add_ngons(ngons);
 
 	return new_brush;
@@ -2054,6 +2079,9 @@ CSGBrush *CSGMesh3D::_build_brush() {
 	Vector<Ref<Material>> materials;
 	Vector<Vector2> uvs;
 	Ref<Material> base_material = get_material();
+	Vector<int> ngons;
+
+	int ngon_counter = 0;
 
 	for (int i = 0; i < mesh->get_surface_count(); i++) {
 		if (mesh->surface_get_primitive_type(i) != Mesh::PRIMITIVE_TRIANGLES) {
@@ -2102,13 +2130,17 @@ CSGBrush *CSGMesh3D::_build_brush() {
 			smooth.resize((as + is) / 3);
 			materials.resize((as + is) / 3);
 			uvs.resize(as + is);
+			ngons.resize((as + is) / 3);
 
 			Vector3 *vw = vertices.ptrw();
 			int *sw = smooth.ptrw();
 			Vector2 *uvw = uvs.ptrw();
 			Ref<Material> *mw = materials.ptrw();
+			int *ngonw = ngons.ptrw();
 
 			const int *ir = aindices.ptr();
+
+			Vector3 prev_tri_normal = Vector3(0, 0, 0);
 
 			for (int j = 0; j < is; j += 3) {
 				Vector3 vertex[3];
@@ -2127,6 +2159,17 @@ CSGBrush *CSGMesh3D::_build_brush() {
 				}
 
 				bool flat = normal[0].is_equal_approx(normal[1]) && normal[0].is_equal_approx(normal[2]);
+
+				if (flat) {
+					if (!prev_tri_normal.is_equal_approx(normal[0])) {
+						ngon_counter++;
+					}
+					prev_tri_normal = normal;
+				} else {
+					prev_tri_normal = Vector3(0, 0, 0);
+					ngon_counter++;
+				}
+				ngonw[(as + j) / 3] = ngon_counter;
 
 				vw[as + j + 0] = vertex[0];
 				vw[as + j + 1] = vertex[1];
@@ -2147,11 +2190,15 @@ CSGBrush *CSGMesh3D::_build_brush() {
 			smooth.resize((as + is) / 3);
 			uvs.resize(as + is);
 			materials.resize((as + is) / 3);
+			ngons.resize((as + is) / 3);
 
 			Vector3 *vw = vertices.ptrw();
 			int *sw = smooth.ptrw();
 			Vector2 *uvw = uvs.ptrw();
 			Ref<Material> *mw = materials.ptrw();
+			int *ngonw = ngons.ptrw();
+
+			Vector3 prev_tri_normal = Vector3(0, 0, 0);
 
 			for (int j = 0; j < is; j += 3) {
 				Vector3 vertex[3];
@@ -2169,6 +2216,17 @@ CSGBrush *CSGMesh3D::_build_brush() {
 				}
 
 				bool flat = normal[0].is_equal_approx(normal[1]) && normal[0].is_equal_approx(normal[2]);
+
+				if (flat) {
+					if (!prev_tri_normal.is_equal_approx(normal[0])) {
+						ngon_counter++;
+					}
+					prev_tri_normal = normal;
+				} else {
+					prev_tri_normal = Vector3(0, 0, 0);
+					ngon_counter++;
+				}
+				ngonw[(as + j) / 3] = ngon_counter;
 
 				vw[as + j + 0] = vertex[0];
 				vw[as + j + 1] = vertex[1];
@@ -2188,7 +2246,7 @@ CSGBrush *CSGMesh3D::_build_brush() {
 		return memnew(CSGBrush);
 	}
 
-	return _create_brush_from_arrays(vertices, uvs, smooth, materials);
+	return _create_brush_from_arrays(vertices, uvs, smooth, materials, ngons);
 }
 
 void CSGMesh3D::_mesh_changed() {
@@ -2446,8 +2504,10 @@ int CSGSphere3D::get_rings() const {
 }
 
 void CSGSphere3D::set_smooth_faces(const bool p_smooth_faces) {
-	set_csg_flat(p_smooth_faces);
 	smooth_faces = p_smooth_faces;
+	if (is_inside_tree()) {
+		set_csg_flat(smooth_faces);
+	}
 	_make_painted();
 }
 
@@ -3117,8 +3177,10 @@ int CSGTorus3D::get_ring_sides() const {
 }
 
 void CSGTorus3D::set_smooth_faces(const bool p_smooth_faces) {
-	set_csg_flat(p_smooth_faces);
 	smooth_faces = p_smooth_faces;
+	if (is_inside_tree()) {
+		set_csg_flat(smooth_faces);
+	}
 	_make_painted();
 }
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -971,8 +971,7 @@ void CSGShape3D::_notification(int p_what) {
 					root_mesh.unref();
 					_make_painted();
 				} else {
-					// I have a theory the linux build doesn't pass the test because this runs before the children are ready.
-					callable_mp(this, &CSGShape3D::rebuild_brush).call_deferred();
+					rebuild_brush();
 				}
 			}
 			last_visible = is_visible();

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1995,7 +1995,7 @@ CSGBrush *CSGPrimitive3D::_create_brush_from_arrays(const Vector<Vector3> &p_ver
 	ngons.resize(new_brush->faces.size());
 	{
 		// Create perfect quads.
-		ERR_FAIL_COND_V(!new_brush->faces.size() > 0, new_brush);
+		ERR_FAIL_COND_V(!(new_brush->faces.size() > 0), new_brush);
 		int ngon_counter = 0;
 		ngons.write[0] = ngon_counter;
 		Vector3 f_vert = new_brush->faces[0].vertices[0];

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1739,7 +1739,7 @@ bool CSGShape3D::is_painted() const {
 	return painted;
 }
 
-Vector<int> CSGShape3D::get_all_csg_faces() const {
+Vector<int> CSGShape3D::get_all_csg_faces() {
 	Vector<int> all_faces;
 	all_faces.resize(get_csg_num_faces());
 	for (int i = 0; i < all_faces.size(); i++) {
@@ -2341,7 +2341,7 @@ bool CSGSphere3D::get_smooth_faces() const {
 
 void CSGSphere3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	set_face_material(get_all_csg_faces(), material)
+	set_face_material(get_all_csg_faces(), material);
 }
 
 Ref<Material> CSGSphere3D::get_material() const {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1822,44 +1822,6 @@ TypedArray<Vector<Vector3>> CSGShape3D::get_csg_ngon_colliders() {
 	return ret;
 }
 
-Vector<Vector3> CSGShape3D::get_all_ngon_lines() {
-	// Nicer looking lines.
-	Vector<Vector3> ret;
-	CSGBrush *n = _get_brush();
-
-	if (n->ngons.is_empty() || n->num_ngons < 1 || n->num_ngons < 0) {
-		// Don't throw error, instead default to older behavior.
-		return ret;
-	}
-
-	// TODO Move to gizmos.
-	TypedArray<Vector<Vector3>> local_csg_faces = get_csg_ngon_colliders();
-
-	// TODO Optimize.
-	for (int i = 0; i < local_csg_faces.size(); i++) {
-		Vector<Vector3> local_edges;
-		Vector<Vector3> curr_ngon = local_csg_faces[i];
-		for (int j = 0; j < curr_ngon.size() / 3; j++) {
-			for (int k = 0; k < 3; k++) {
-				int k_n = (k + 1) % 3;
-				local_edges.push_back(curr_ngon[j * 3 + k]);
-				local_edges.push_back(curr_ngon[j * 3 + k_n]);
-			}
-		}
-		for (int j = 0; j < local_edges.size() / 2; j++) {
-			for (int k = j; k < local_edges.size() / 2; k++) {
-				// TODO Simplify.
-				bool comp_edges = (local_edges[j * 2] == local_edges[k * 2] && local_edges[j * 2 + 1] == local_edges[k * 2 + 1]) && (local_edges[j * 2] == local_edges[k * 2 + 1] && local_edges[j * 2 + 1] == local_edges[k * 2]);
-				if (!comp_edges) {
-					ret.push_back(local_edges[j * 2]);
-					ret.push_back(local_edges[j * 2 + 1]);
-				}
-			}
-		}
-	}
-	return ret;
-}
-
 bool CSGShape3D::is_painted() const {
 	return painted;
 }
@@ -2031,8 +1993,21 @@ CSGBrush *CSGPrimitive3D::_create_brush_from_arrays(const Vector<Vector3> &p_ver
 	// Meshes are imported as triangles so there's no way to use quads from here.
 	Vector<int> ngons;
 	ngons.resize(new_brush->faces.size());
-	for (int i = 0; i < ngons.size(); i++) {
-		ngons.write[i] = i;
+	{
+		// Create perfect quads.
+		ERR_FAIL_COND_V(!new_brush->faces.size() > 0, new_brush);
+		int ngon_counter = 0;
+		ngons.write[0] = ngon_counter;
+		Vector3 f_vert =  new_brush->faces[0].vertices[0];
+		Vector3 l_vert = new_brush->faces[0].vertices[2];
+		for (int i = 1; i < ngons.size(); i++) {
+			if (!f_vert.is_equal_approx(new_brush->faces[i].vertices[2]) || !l_vert.is_equal_approx(new_brush->faces[i].vertices[0])) {
+				ngon_counter++;
+			}
+			ngons.write[i] = ngon_counter;
+			f_vert = new_brush->faces[i].vertices[0];
+			l_vert = new_brush->faces[i].vertices[2];
+		}
 	}
 
 	new_brush->add_ngons(ngons);
@@ -2542,6 +2517,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 		Vector3 vertex_mul = size / 2;
 
 		{
+			int ngon_counter = 0;
 			for (int i = 0; i < 6; i++) {
 				Vector3 face_points[4];
 				float uv_points[8] = { 0, 0, 0, 1, 1, 1, 1, 0 };
@@ -2578,6 +2554,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 				smoothw[face] = false;
 				invertw[face] = invert_val;
 				materialsw[face] = base_material;
+				ngonw[face] = ngon_counter;
 
 				face++;
 				//face 2
@@ -2592,8 +2569,8 @@ CSGBrush *CSGBox3D::_build_brush() {
 				smoothw[face] = false;
 				invertw[face] = invert_val;
 				materialsw[face] = base_material;
-
-				ngonw[face] = face / 2;
+				ngonw[face] = ngon_counter;
+				ngon_counter++;
 
 				face++;
 			}

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1016,7 +1016,7 @@ void CSGShape3D::_notification(int p_what) {
 				set_collision_mask(collision_mask);
 				set_collision_priority(collision_priority);
 				debug_shape_old_transform = get_global_transform();
-				rebuild_brush();
+				_make_painted();
 			}
 		} break;
 
@@ -1173,7 +1173,6 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 
 	if (!p_brush_data["painted"]) {
 		// Brush has not been modified or is root shape. Rebuild brush.
-		dirty = true;
 		return;
 	}
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -273,11 +273,11 @@ void CSGShape3D::_make_painted(bool p_paint, bool p_parent_removing) {
 	} else if (!brush) {
 		_make_dirty();
 	} else if (!is_root_shape()) {
-		if (!painted && !p_paint) {
+		painted = painted || p_paint;
+		if (!painted) {
 			_make_dirty();
 			return;
 		}
-		painted = painted || p_paint;
 		notify_property_list_changed();
 		// We force a rebuild of the root shape only.
 		parent_shape->_make_painted();
@@ -961,10 +961,8 @@ void CSGShape3D::_notification(int p_what) {
 				if (parent_shape) {
 					set_base(RID());
 					root_mesh.unref();
+					_make_painted();
 				}
-			}
-			if (parent_shape) {
-				_make_painted();
 			}
 			last_visible = is_visible();
 		} break;
@@ -972,7 +970,6 @@ void CSGShape3D::_notification(int p_what) {
 		case NOTIFICATION_UNPARENTED: {
 			if (!is_root_shape()) {
 				// Update this node and its previous parent only if it's currently being removed from another CSG shape
-				// TODO investigate.
 				_make_painted(false, true); // Must be forced since is_root_shape() uses the previous parent
 			}
 			parent_shape = nullptr;
@@ -1099,8 +1096,6 @@ Dictionary CSGShape3D::get_csg_brush() {
 	}
 
 	if (is_root_shape()) {
-		// Ideally, we want to rebuild the brush to undo any manifold operations.
-		// Changes on parents of nested shapes would be undone, it would be best if all shapes were siblings.
 		return p_brush_data;
 	}
 
@@ -1154,6 +1149,7 @@ Dictionary CSGShape3D::get_csg_brush() {
 void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 	if (!p_brush_data.has("painted")) {
 		// Rebuild brush.
+		ERR_PRINT("Node doesn't have a _csg_brush Dictionary");
 		return;
 	}
 
@@ -1613,7 +1609,7 @@ void CSGShape3D::calculate_cube_map(const Vector<int> &p_faces) {
 
 		if (nor.x > nor.y && nor.x > nor.z) {
 			// Direction X, ZY.
-			float mir_x = ang.normal.x < 0.0 ? -1.0 : 0.0;
+			float mir_x = ang.normal.x < 0.0 ? -1.0 : 1.0;
 			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(mir_x * v1.z, v1.y));
 			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(mir_x * v2.z, v2.y));
 			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(mir_x * v3.z, v3.y));
@@ -1625,7 +1621,7 @@ void CSGShape3D::calculate_cube_map(const Vector<int> &p_faces) {
 			n->faces.write[p].uvs[2] = Vector2(mir_x * v3.x, v3.z);
 		} else {
 			// Direction Z, XY.
-			float mir_x = ang.normal.z < 0.0 ? -1.0 : 0.0;
+			float mir_x = ang.normal.z < 0.0 ? -1.0 : 1.0;
 			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(mir_x * v1.x, v1.y));
 			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(mir_x * v2.x, v2.y));
 			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(mir_x * v3.x, v3.y));

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1097,143 +1097,6 @@ void CSGShape3D::get_csg_children_recursive(Vector<CSGShape3D *> &p_nodes) {
 	}
 }
 
-Dictionary CSGShape3D::get_csg_brush() {
-	Dictionary p_brush_data;
-	p_brush_data["painted"] = painted;
-
-	if (!brush) {
-		return p_brush_data;
-	}
-
-	if (is_root_shape()) {
-		return p_brush_data;
-	}
-
-	if (!painted) {
-		// Only save painted brushes.
-		return p_brush_data;
-	}
-
-	CSGBrush *n = _get_brush();
-	if (n == nullptr) {
-		return p_brush_data;
-	}
-
-	if (n->faces.size() <= 0) {
-		return p_brush_data;
-	}
-
-	Vector<Vector3> vertices;
-	Vector<Vector2> uvs;
-	Vector<uint8_t> smooths;
-	Vector<uint8_t> mat_id;
-	Array materials;
-
-	for (int i = 0; i < n->faces.size(); i++) {
-		for (int j = 0; j < 3; j++) {
-			vertices.push_back(n->faces[i].vertices[j]);
-			uvs.push_back(n->faces[i].uvs[j]);
-		}
-
-		smooths.push_back(n->faces[i].smooth ? 1 : 0);
-		mat_id.push_back(n->faces[i].material);
-	}
-
-	p_brush_data["vertices"] = vertices;
-	p_brush_data["uvs"] = uvs;
-	// Replace with smooth groups in the future.
-	p_brush_data["smooth"] = smooths;
-	// We will not save combined shapes.
-	p_brush_data["material_id"] = mat_id;
-	p_brush_data["ngons"] = n->ngons;
-
-	for (int i = 0; i < n->materials.size(); i++) {
-		materials.push_back(n->materials[i]);
-	}
-
-	p_brush_data["materials"] = materials;
-
-	return p_brush_data;
-}
-
-void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
-	if (!p_brush_data.has("painted")) {
-		// Rebuild brush.
-		ERR_PRINT("Node doesn't have a valid _csg_brush Dictionary");
-		return;
-	}
-
-	if (!p_brush_data["painted"]) {
-		// Brush has not been modified or is root shape. Rebuild brush.
-		dirty = true;
-		return;
-	}
-
-	ERR_FAIL_COND(!p_brush_data.has("material_id"));
-	ERR_FAIL_COND(!p_brush_data.has("vertices"));
-	ERR_FAIL_COND(!p_brush_data.has("uvs"));
-	ERR_FAIL_COND(!p_brush_data.has("smooth"));
-	ERR_FAIL_COND(!p_brush_data.has("materials"));
-
-	painted = p_brush_data["painted"];
-
-	CSGBrush *n = memnew(CSGBrush);
-
-	Vector<uint8_t> mat_id = p_brush_data["material_id"];
-
-	int face_count = mat_id.size();
-
-	Vector<Vector3> faces = p_brush_data["vertices"];
-	Vector<Vector2> uvs = p_brush_data["uvs"];
-	Vector<bool> smooth;
-	Vector<Ref<Material>> materials;
-	Vector<bool> invert;
-
-	smooth.resize(face_count);
-	materials.resize(face_count);
-	invert.resize(face_count);
-
-	{
-		bool invrt = get_flip_faces();
-		Vector<uint8_t> smooth_i = p_brush_data["smooth"];
-		Array mats = p_brush_data["materials"];
-
-		bool *smoothw = smooth.ptrw();
-		Ref<Material> *materialsw = materials.ptrw();
-		bool *invertw = invert.ptrw();
-
-		for (int i = 0; i < face_count; i++) {
-			smoothw[i] = smooth_i[i] > 0;
-			int i_mat = mat_id[i];
-			if (i_mat < mats.size()) {
-				Ref<Material> t_mat = mats[i_mat];
-				if (t_mat.is_valid()) {
-					materialsw[i] = t_mat;
-				} else {
-					materialsw[i] = nullptr;
-				}
-			}
-			invertw[i] = invrt;
-		}
-	}
-
-	n->build_from_faces(faces, uvs, smooth, materials, invert);
-
-	if (p_brush_data.has("ngons")) {
-		n->add_ngons(p_brush_data["ngons"]);
-	} else {
-		WARN_PRINT("Resource doesn't have ngon data");
-	}
-
-	if (brush) {
-		memdelete(brush);
-	}
-
-	brush = n;
-
-	dirty = false;
-}
-
 void CSGShape3D::rebuild_brush() {
 	_make_dirty();
 }
@@ -1803,7 +1666,7 @@ TypedArray<Vector<Vector3>> CSGShape3D::get_csg_ngon_colliders() {
 	ret.resize(n->num_ngons);
 	for (int i = 0; i < n->num_ngons; i++) {
 		Vector<int> curr_ngon = n->get_ngon_faces(i);
-		if (curr_ngon != nullptr) {
+		if (!curr_ngon.is_empty()) {
 			Vector<Vector3> curr_faces;
 			for (int j = 0; j < curr_ngon.size(); j++) {
 				curr_faces.push_back(n->faces[j].vertices[0]);
@@ -1814,7 +1677,8 @@ TypedArray<Vector<Vector3>> CSGShape3D::get_csg_ngon_colliders() {
 		}
 	}
 
-	if (get_flip_faces() || get_operation() == OPERATION_SUBTRACTION) {
+	// TODO get_flip_faces().
+	if (get_operation() == OPERATION_SUBTRACTION) {
 		ret.reverse();
 	}
 
@@ -1837,11 +1701,12 @@ Vector<Vector3> CSGShape3D::get_all_ngon_lines() {
 	// TODO Optimize.
 	for (int i = 0; i < local_csg_faces.size(); i++) {
 		Vector<Vector3> local_edges;
-		for (int j = 0; j < local_csg_faces[i].size() / 3; j++) {
+		Vector<Vector3> curr_ngon = local_csg_faces[i];
+		for (int j = 0; j < curr_ngon.size() / 3; j++) {
 			for (int k = 0; k < 3; k++) {
 				int k_n = (k + 1) % 3;
-				local_edges.push_back(local_csg_faces[i * 3 + k]);
-				local_edges.push_back(local_csg_faces[i * 3 + k_n]);
+				local_edges.push_back(curr_ngon[j * 3 + k]);
+				local_edges.push_back(curr_ngon[j * 3 + k_n]);
 			}
 		}
 		for (int j = 0; j < local_edges.size() / 2; j++) {
@@ -1933,9 +1798,6 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_calculate_tangents", "enabled"), &CSGShape3D::set_calculate_tangents);
 	ClassDB::bind_method(D_METHOD("is_calculating_tangents"), &CSGShape3D::is_calculating_tangents);
 
-	ClassDB::bind_method(D_METHOD("set_csg_brush", "csg_brush"), &CSGShape3D::set_csg_brush);
-	ClassDB::bind_method(D_METHOD("get_csg_brush"), &CSGShape3D::get_csg_brush);
-
 	ClassDB::bind_method(D_METHOD("rebuild_brush"), &CSGShape3D::rebuild_brush);
 	ClassDB::bind_method(D_METHOD("set_uv_offsets", "faces", "prev_offset", "p_offset"), &CSGShape3D::set_uv_offsets);
 	ClassDB::bind_method(D_METHOD("get_uv_offsets", "face"), &CSGShape3D::get_uv_offsets);
@@ -1967,8 +1829,6 @@ void CSGShape3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_smoothing_angle", "smoothing_angle"), &CSGShape3D::set_smoothing_angle);
 	ClassDB::bind_method(D_METHOD("get_smoothing_angle"), &CSGShape3D::get_smoothing_angle);
-
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_csg_brush", PROPERTY_HINT_NO_NODEPATH, "", PROPERTY_USAGE_NO_EDITOR), "set_csg_brush", "get_csg_brush");
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autosmooth"), "set_autosmooth", "is_autosmooth");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "smoothing_angle", PROPERTY_HINT_RANGE, "0,180,0.1,degrees"), "set_smoothing_angle", "get_smoothing_angle");
@@ -2044,7 +1904,11 @@ void CSGPrimitive3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_flip_faces", "flip_faces"), &CSGPrimitive3D::set_flip_faces);
 	ClassDB::bind_method(D_METHOD("get_flip_faces"), &CSGPrimitive3D::get_flip_faces);
 
+	ClassDB::bind_method(D_METHOD("set_csg_brush", "csg_brush"), &CSGPrimitive3D::set_csg_brush);
+	ClassDB::bind_method(D_METHOD("get_csg_brush"), &CSGPrimitive3D::get_csg_brush);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_faces"), "set_flip_faces", "get_flip_faces");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_csg_brush", PROPERTY_HINT_NO_NODEPATH, "", PROPERTY_USAGE_NO_EDITOR), "set_csg_brush", "get_csg_brush");
 }
 
 void CSGPrimitive3D::set_flip_faces(bool p_invert) {
@@ -2063,6 +1927,143 @@ void CSGPrimitive3D::set_flip_faces(bool p_invert) {
 
 bool CSGPrimitive3D::get_flip_faces() {
 	return flip_faces;
+}
+
+Dictionary CSGPrimitive3D::get_csg_brush() {
+	Dictionary p_brush_data;
+	p_brush_data["painted"] = painted;
+
+	if (!brush) {
+		return p_brush_data;
+	}
+
+	if (is_root_shape()) {
+		return p_brush_data;
+	}
+
+	if (!painted) {
+		// Only save painted brushes.
+		return p_brush_data;
+	}
+
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return p_brush_data;
+	}
+
+	if (n->faces.size() <= 0) {
+		return p_brush_data;
+	}
+
+	Vector<Vector3> vertices;
+	Vector<Vector2> uvs;
+	Vector<uint8_t> smooths;
+	Vector<uint8_t> mat_id;
+	Array materials;
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		for (int j = 0; j < 3; j++) {
+			vertices.push_back(n->faces[i].vertices[j]);
+			uvs.push_back(n->faces[i].uvs[j]);
+		}
+
+		smooths.push_back(n->faces[i].smooth ? 1 : 0);
+		mat_id.push_back(n->faces[i].material);
+	}
+
+	p_brush_data["vertices"] = vertices;
+	p_brush_data["uvs"] = uvs;
+	// Replace with smooth groups in the future.
+	p_brush_data["smooth"] = smooths;
+	// We will not save combined shapes.
+	p_brush_data["material_id"] = mat_id;
+	p_brush_data["ngons"] = n->ngons;
+
+	for (int i = 0; i < n->materials.size(); i++) {
+		materials.push_back(n->materials[i]);
+	}
+
+	p_brush_data["materials"] = materials;
+
+	return p_brush_data;
+}
+
+void CSGPrimitive3D::set_csg_brush(const Dictionary &p_brush_data) {
+	if (!p_brush_data.has("painted")) {
+		// Rebuild brush.
+		ERR_PRINT("Node doesn't have a valid _csg_brush Dictionary");
+		return;
+	}
+
+	if (!p_brush_data["painted"]) {
+		// Brush has not been modified or is root shape. Rebuild brush.
+		dirty = true;
+		return;
+	}
+
+	ERR_FAIL_COND(!p_brush_data.has("material_id"));
+	ERR_FAIL_COND(!p_brush_data.has("vertices"));
+	ERR_FAIL_COND(!p_brush_data.has("uvs"));
+	ERR_FAIL_COND(!p_brush_data.has("smooth"));
+	ERR_FAIL_COND(!p_brush_data.has("materials"));
+
+	painted = p_brush_data["painted"];
+
+	CSGBrush *n = memnew(CSGBrush);
+
+	Vector<uint8_t> mat_id = p_brush_data["material_id"];
+
+	int face_count = mat_id.size();
+
+	Vector<Vector3> faces = p_brush_data["vertices"];
+	Vector<Vector2> uvs = p_brush_data["uvs"];
+	Vector<bool> smooth;
+	Vector<Ref<Material>> materials;
+	Vector<bool> invert;
+
+	smooth.resize(face_count);
+	materials.resize(face_count);
+	invert.resize(face_count);
+
+	{
+		bool invrt = get_flip_faces();
+		Vector<uint8_t> smooth_i = p_brush_data["smooth"];
+		Array mats = p_brush_data["materials"];
+
+		bool *smoothw = smooth.ptrw();
+		Ref<Material> *materialsw = materials.ptrw();
+		bool *invertw = invert.ptrw();
+
+		for (int i = 0; i < face_count; i++) {
+			smoothw[i] = smooth_i[i] > 0;
+			int i_mat = mat_id[i];
+			if (i_mat < mats.size()) {
+				Ref<Material> t_mat = mats[i_mat];
+				if (t_mat.is_valid()) {
+					materialsw[i] = t_mat;
+				} else {
+					materialsw[i] = nullptr;
+				}
+			}
+			invertw[i] = invrt;
+		}
+	}
+
+	n->build_from_faces(faces, uvs, smooth, materials, invert);
+
+	if (p_brush_data.has("ngons")) {
+		n->add_ngons(p_brush_data["ngons"]);
+	} else {
+		WARN_PRINT("Resource doesn't have ngon data");
+	}
+
+	if (brush) {
+		memdelete(brush);
+	}
+
+	brush = n;
+
+	dirty = false;
 }
 
 CSGPrimitive3D::CSGPrimitive3D() {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1800,7 +1800,6 @@ TypedArray<Vector<Vector3>> CSGShape3D::get_csg_ngon_colliders() {
 		return ret;
 	}
 
-	ret.resize(n->num_ngons);
 	for (int i = 0; i < n->num_ngons; i++) {
 		Vector<int> curr_ngon = n->get_ngon_faces(i);
 		if (!curr_ngon.is_empty()) {
@@ -1810,11 +1809,11 @@ TypedArray<Vector<Vector3>> CSGShape3D::get_csg_ngon_colliders() {
 				curr_faces.push_back(n->faces[j].vertices[1]);
 				curr_faces.push_back(n->faces[j].vertices[2]);
 			}
-			ret[i] = curr_faces;
+			ret.push_back(curr_faces);
 		}
 	}
 
-	// TODO get_flip_faces().
+	// Flip faces so they can be selected from the inside.
 	if (get_operation() == OPERATION_SUBTRACTION) {
 		ret.reverse();
 	}

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -266,7 +266,7 @@ void CSGShape3D::_make_dirty(bool p_parent_removing) {
 	notify_property_list_changed();
 }
 
-void CSGShape3D::_make_painted(bool p_paint = false) {
+void CSGShape3D::_make_painted(bool p_paint) {
 	if (!brush) {
 		_make_dirty();
 	} else if (!is_root_shape()) {
@@ -1077,7 +1077,7 @@ void CSGShape3D::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
-void get_csg_children_recursive(Vector<CSGShape3D *> &p_nodes) {
+void CSGShape3D::get_csg_children_recursive(Vector<CSGShape3D *> &p_nodes) {
 	for (int i = 0; i < get_child_count(); i++) {
 		CSGShape3D *child = Object::cast_to<CSGShape3D>(get_child(i));
 		if (!child || !child->is_visible()) {
@@ -1607,7 +1607,9 @@ Vector<Vector3> CSGShape3D::get_selected_faces(const Vector<int> &p_faces) {
 
 	for (int i = 0; i < p_faces.size(); i++) {
 		int p = p_faces[i];
-		ERR_FAIL_INDEX(p, n->faces.size());
+		if (p > n->faces.size() || p < 0) {
+			continue;
+		}
 		for (int j = 0; j < 3; j++) {
 			ret.push_back(n->faces[p].vertices[j]);
 		}

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1906,8 +1906,8 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("flip_x", "faces"), &CSGShape3D::flip_x);
 	ClassDB::bind_method(D_METHOD("flip_y", "faces"), &CSGShape3D::flip_y);
 	ClassDB::bind_method(D_METHOD("calculate_cube_map", "faces"), &CSGShape3D::calculate_cube_map);
-	ClassDB::bind_method(D_METHOD("set_csg_face_smooth", "faces", "smooth"), &CSGShape3D::set_csg_face_smooth);
-	ClassDB::bind_method(D_METHOD("is_csg_face_smooth", "face"), &CSGShape3D::is_csg_face_smooth);
+	ClassDB::bind_method(D_METHOD("set_csg_face_smooth_group", "faces", "smooth"), &CSGShape3D::set_csg_face_smooth_group);
+	ClassDB::bind_method(D_METHOD("get_csg_face_smooth_group", "face"), &CSGShape3D::get_csg_face_smooth_group);
 	ClassDB::bind_method(D_METHOD("set_face_material", "faces", "material"), &CSGShape3D::set_face_material);
 	ClassDB::bind_method(D_METHOD("get_face_material", "face"), &CSGShape3D::get_face_material);
 	ClassDB::bind_method(D_METHOD("resize_brush", "prev_size", "size"), &CSGShape3D::resize_brush);

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -978,7 +978,7 @@ void CSGShape3D::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			// Trying to make the brush build only once all children are inside the tree.
 			if (is_root_shape()) {
-				rebuild();
+				rebuild_brush();
 			}
 		} break;
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -507,7 +507,7 @@ struct ManifoldOperation {
 };
 
 CSGBrush *CSGShape3D::_get_brush() {
-	if (!dirty) {
+	if (!dirty || !is_inside_tree()) {
 		return brush;
 	}
 	if (brush) {
@@ -1494,7 +1494,7 @@ void CSGShape3D::calculate_cylinder_map(const Vector<int> &p_faces) {
 
 		Plane ang(v1, v2, v3);
 		Vector3 start_vec = Vector3(1.0, 0.0, 0.0);
-		if (Math::abs(ang.normal.y) > 0) {
+		if (Math::abs(ang.normal.y) > 0.6) {
 			// Top and bottom faces.
 			float mir_x = ang.normal.x < 0.0 ? -1.0 : 1.0;
 			n->faces.write[p].uvs[0] = Vector2(mir_x * v1.x, v1.z);
@@ -1503,8 +1503,8 @@ void CSGShape3D::calculate_cylinder_map(const Vector<int> &p_faces) {
 		} else {
 			float shift_x = ang.normal.z < 0.0 ? -1.0 : 1.0;
 			Vector3 t_ang_1 = Vector3(v1.x, 0.0, v1.z).normalized();
-			Vector3 t_ang_2 = Vector3(v1.x, 0.0, v1.z).normalized();
-			Vector3 t_ang_3 = Vector3(v1.x, 0.0, v1.z).normalized();
+			Vector3 t_ang_2 = Vector3(v2.x, 0.0, v2.z).normalized();
+			Vector3 t_ang_3 = Vector3(v3.x, 0.0, v3.z).normalized();
 			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(shift_x * start_vec.dot(t_ang_1), v1.y));
 			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(shift_x * start_vec.dot(t_ang_2), v2.y));
 			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(shift_x * start_vec.dot(t_ang_3), v3.y));

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1494,7 +1494,7 @@ Ref<Material> CSGShape3D::get_face_material(int p_face) {
 
 Vector<Vector3> CSGShape3D::get_vertices() {
 	// Use this for making a vertex editor.
-	CSGBox3D *n = _get_brush();
+	CSGBrush *n = _get_brush();
 
 	Vector<Vector3> vertices;
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -975,6 +975,13 @@ void CSGShape3D::_notification(int p_what) {
 			last_visible = is_visible();
 		} break;
 
+		case NOTIFICATION_READY: {
+			// Trying to make the brush build only once all children are inside the tree.
+			if (is_root_shape()) {
+				rebuild();
+			}
+		} break;
+
 		case NOTIFICATION_UNPARENTED: {
 			if (!is_root_shape()) {
 				// Update this node and its previous parent only if it's currently being removed from another CSG shape

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -283,7 +283,7 @@ void CSGShape3D::_make_painted(bool p_paint, bool p_parent_removing) {
 		// We force a rebuild of the root shape only.
 		parent_shape->_make_painted();
 	} else {
-		// I have a theory the bug happens because properties are set before add_child, so the node is root shape because it doesn't have a parent.
+		// Properties are set before add_child, so the node is root shape because it doesn't have a parent.
 		if (is_inside_tree()) {
 			// With this we can replace most calls to _make_dirty().
 			_make_dirty();
@@ -519,14 +519,13 @@ CSGBrush *CSGShape3D::_get_brush() {
 		// CSG tree must iterate over all shapes, but we gain the ability to edit parent brushes and save them in their base form.
 		HashMap<int32_t, Ref<Material>> mesh_materials;
 		manifold::Manifold root_manifold;
-		CSGBrush trans_root;
-		trans_root.copy_from(*n, get_global_transform());
-		_pack_manifold(&trans_root, root_manifold, mesh_materials, this);
+		_pack_manifold(n, root_manifold, mesh_materials, this);
 		manifold::OpType current_op = ManifoldOperation::convert_csg_op(get_operation());
 		std::vector<manifold::Manifold> manifolds;
 		manifolds.push_back(root_manifold);
 		Vector<CSGShape3D *> children;
 		get_csg_children_recursive(children);
+		Transform3D afinv = get_global_transform().affine_inverse();
 		for (int i = 0; i < children.size(); i++) {
 			CSGShape3D *child = children[i];
 			CSGBrush *child_brush = child->_get_brush();
@@ -534,7 +533,7 @@ CSGBrush *CSGShape3D::_get_brush() {
 				continue;
 			}
 			CSGBrush transformed_brush;
-			transformed_brush.copy_from(*child_brush, child->get_global_transform()); // Changing this to global for nested nodes. We now need to transform the root shape too.
+			transformed_brush.copy_from(*child_brush, afinv * child->get_global_transform());
 			manifold::Manifold child_manifold;
 			_pack_manifold(&transformed_brush, child_manifold, mesh_materials, child);
 			manifold::OpType child_operation = ManifoldOperation::convert_csg_op(child->get_operation());
@@ -966,6 +965,8 @@ void CSGShape3D::_notification(int p_what) {
 					set_base(RID());
 					root_mesh.unref();
 					_make_painted();
+				} else {
+					rebuild_brush();
 				}
 			}
 			last_visible = is_visible();
@@ -1153,12 +1154,13 @@ Dictionary CSGShape3D::get_csg_brush() {
 void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 	if (!p_brush_data.has("painted")) {
 		// Rebuild brush.
-		ERR_PRINT("Node doesn't have a _csg_brush Dictionary");
+		ERR_PRINT("Node doesn't have a valid _csg_brush Dictionary");
 		return;
 	}
 
 	if (!p_brush_data["painted"]) {
 		// Brush has not been modified or is root shape. Rebuild brush.
+		dirty = true;
 		return;
 	}
 
@@ -2100,7 +2102,9 @@ void CSGMesh3D::set_material(const Ref<Material> &p_material) {
 		return;
 	}
 	material = p_material;
-	set_face_material(get_all_csg_faces(), material);
+	if (is_inside_tree()) {
+		set_face_material(get_all_csg_faces(), material);
+	}
 }
 
 Ref<Material> CSGMesh3D::get_material() const {
@@ -2341,7 +2345,9 @@ bool CSGSphere3D::get_smooth_faces() const {
 
 void CSGSphere3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	set_face_material(get_all_csg_faces(), material);
+	if (is_inside_tree()) {
+		set_face_material(get_all_csg_faces(), material);
+	}
 }
 
 Ref<Material> CSGSphere3D::get_material() const {
@@ -2472,7 +2478,7 @@ void CSGBox3D::_bind_methods() {
 void CSGBox3D::set_size(const Vector3 &p_size) {
 	if (!is_painted()) {
 		size = p_size;
-	} else if (resize_brush(size, p_size)) {
+	} else if (resize_brush(size / 2, p_size / 2)) {
 		size = p_size;
 	}
 	_make_painted();
@@ -2509,7 +2515,9 @@ bool CSGBox3D::_set(const StringName &p_name, const Variant &p_value) {
 
 void CSGBox3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	set_face_material(get_all_csg_faces(), material);
+	if (is_inside_tree()) {
+		set_face_material(get_all_csg_faces(), material);
+	}
 	update_gizmos();
 }
 
@@ -2698,7 +2706,7 @@ float CSGCylinder3D::get_radius() const {
 void CSGCylinder3D::set_height(const float p_height) {
 	if (!is_painted()) {
 		height = p_height;
-	} else if (resize_brush(Vector3(1.0, height, 1.0), Vector3(1.0, p_height, 1.0))) {
+	} else if (resize_brush(Vector3(1.0, height * 0.5, 1.0), Vector3(1.0, p_height * 0.5, 1.0))) {
 		height = p_height;
 	}
 	_make_painted();
@@ -2741,7 +2749,9 @@ bool CSGCylinder3D::get_smooth_faces() const {
 
 void CSGCylinder3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	set_face_material(get_all_csg_faces(), material);
+	if (is_inside_tree()) {
+		set_face_material(get_all_csg_faces(), material);
+	}
 }
 
 Ref<Material> CSGCylinder3D::get_material() const {
@@ -2968,7 +2978,9 @@ bool CSGTorus3D::get_smooth_faces() const {
 
 void CSGTorus3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	set_face_material(get_all_csg_faces(), material);
+	if (is_inside_tree()) {
+		set_face_material(get_all_csg_faces(), material);
+	}
 }
 
 Ref<Material> CSGTorus3D::get_material() const {
@@ -3628,7 +3640,9 @@ bool CSGPolygon3D::get_smooth_faces() const {
 
 void CSGPolygon3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	set_face_material(get_all_csg_faces(), material);
+	if (is_inside_tree()) {
+		set_face_material(get_all_csg_faces(), material);
+	}
 }
 
 Ref<Material> CSGPolygon3D::get_material() const {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -971,7 +971,8 @@ void CSGShape3D::_notification(int p_what) {
 					root_mesh.unref();
 					_make_painted();
 				} else {
-					rebuild_brush();
+					// I have a theory the linux build doesn't pass the test because this runs before the children are ready.
+					callable_mp(this, &CSGShape3D::rebuild_brush).call_deferred();
 				}
 			}
 			last_visible = is_visible();

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -976,7 +976,7 @@ void CSGShape3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
-			// Trying to make the brush build only once all children are inside the tree.
+			// Build the brush build only once all children are inside the tree.
 			if (is_root_shape()) {
 				rebuild_brush();
 			}
@@ -1155,7 +1155,6 @@ Dictionary CSGShape3D::get_csg_brush() {
 
 	p_brush_data["vertices"] = vertices;
 	p_brush_data["uvs"] = uvs;
-	// Replace with smooth groups in the future.
 	p_brush_data["smooth"] = smooths;
 	// We will not save combined shapes.
 	p_brush_data["inverted"] = n->faces[0].invert;
@@ -1679,6 +1678,48 @@ bool CSGShape3D::resize_brush(const Vector3 &prev_size, const Vector3 &p_size) {
 		}
 	}
 	return true;
+}
+
+void CSGShape3D::resize_brush_rework() {
+	// Resizes the brush without lossing changes. Used for CSGTorus3D.
+	if (!is_inside_tree()) {
+		return;
+	}
+
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return;
+	}
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	CSGBrush *b = _build_brush();
+
+	if (b->faces.size() != n->faces.size()) {
+		memdelete(b);
+		return;
+	}
+
+	AABB aabb;
+	if (b) {
+		if (!b->faces.is_empty()) {
+			aabb.position = b->faces[0].vertices[0];
+			for (const CSGBrush::Face &face : b->faces) {
+				for (int i = 0; i < 3; ++i) {
+					aabb.expand_to(face.vertices[i]);
+				}
+			}
+			for (int i = 0; i < n->faces.size(); i++) {
+				for (int j = 0; j < 3; j++) {
+					n->faces.write[i].vertices[j] = b->faces[i].vertices[j];
+				}
+			}
+		}
+		memdelete(b);
+	}
+	node_aabb = aabb;
 }
 
 void CSGShape3D::set_csg_invert(bool inv_val) {
@@ -2491,7 +2532,9 @@ float CSGSphere3D::get_radius() const {
 
 void CSGSphere3D::set_radial_segments(const int p_radial_segments) {
 	radial_segments = p_radial_segments > 4 ? p_radial_segments : 4;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -2501,7 +2544,9 @@ int CSGSphere3D::get_radial_segments() const {
 
 void CSGSphere3D::set_rings(const int p_rings) {
 	rings = p_rings > 1 ? p_rings : 1;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -2923,7 +2968,9 @@ float CSGCylinder3D::get_height() const {
 void CSGCylinder3D::set_sides(const int p_sides) {
 	ERR_FAIL_COND(p_sides < 3);
 	sides = p_sides;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -2933,7 +2980,9 @@ int CSGCylinder3D::get_sides() const {
 
 void CSGCylinder3D::set_cone(const bool p_cone) {
 	cone = p_cone;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -3142,6 +3191,7 @@ void CSGTorus3D::_bind_methods() {
 
 void CSGTorus3D::set_inner_radius(const float p_inner_radius) {
 	inner_radius = p_inner_radius;
+	resize_brush_rework();
 	_make_painted();
 	update_gizmos();
 }
@@ -3152,6 +3202,7 @@ float CSGTorus3D::get_inner_radius() const {
 
 void CSGTorus3D::set_outer_radius(const float p_outer_radius) {
 	outer_radius = p_outer_radius;
+	resize_brush_rework();
 	_make_painted();
 	update_gizmos();
 }
@@ -3162,8 +3213,10 @@ float CSGTorus3D::get_outer_radius() const {
 
 void CSGTorus3D::set_sides(const int p_sides) {
 	ERR_FAIL_COND(p_sides < 3);
-	sides = p_sides;
-	_make_painted();
+	if (is_inside_tree()) {
+		sides = p_sides;
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -3173,8 +3226,10 @@ int CSGTorus3D::get_sides() const {
 
 void CSGTorus3D::set_ring_sides(const int p_ring_sides) {
 	ERR_FAIL_COND(p_ring_sides < 3);
-	ring_sides = p_ring_sides;
-	_make_painted();
+	if (is_inside_tree()) {
+		ring_sides = p_ring_sides;
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -3711,7 +3766,9 @@ void CSGPolygon3D::_bind_methods() {
 
 void CSGPolygon3D::set_polygon(const Vector<Vector2> &p_polygon) {
 	polygon = p_polygon;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -3721,7 +3778,9 @@ Vector<Vector2> CSGPolygon3D::get_polygon() const {
 
 void CSGPolygon3D::set_mode(Mode p_mode) {
 	mode = p_mode;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 	notify_property_list_changed();
 }
@@ -3733,6 +3792,7 @@ CSGPolygon3D::Mode CSGPolygon3D::get_mode() const {
 void CSGPolygon3D::set_depth(const float p_depth) {
 	ERR_FAIL_COND(p_depth < 0.001);
 	depth = p_depth;
+	resize_brush_rework();
 	_make_painted();
 	update_gizmos();
 }
@@ -3743,7 +3803,9 @@ float CSGPolygon3D::get_depth() const {
 
 void CSGPolygon3D::set_path_continuous_u(bool p_enable) {
 	path_continuous_u = p_enable;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 }
 
 bool CSGPolygon3D::is_path_continuous_u() const {
@@ -3752,7 +3814,9 @@ bool CSGPolygon3D::is_path_continuous_u() const {
 
 void CSGPolygon3D::set_path_u_distance(real_t p_path_u_distance) {
 	path_u_distance = p_path_u_distance;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -3763,7 +3827,9 @@ real_t CSGPolygon3D::get_path_u_distance() const {
 void CSGPolygon3D::set_spin_degrees(const float p_spin_degrees) {
 	ERR_FAIL_COND(p_spin_degrees < 0.01 || p_spin_degrees > 360);
 	spin_degrees = p_spin_degrees;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -3774,7 +3840,9 @@ float CSGPolygon3D::get_spin_degrees() const {
 void CSGPolygon3D::set_spin_sides(int p_spin_sides) {
 	ERR_FAIL_COND(p_spin_sides < 3);
 	spin_sides = p_spin_sides;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -3784,7 +3852,9 @@ int CSGPolygon3D::get_spin_sides() const {
 
 void CSGPolygon3D::set_path_node(const NodePath &p_path) {
 	path_node = p_path;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -3794,7 +3864,9 @@ NodePath CSGPolygon3D::get_path_node() const {
 
 void CSGPolygon3D::set_path_interval_type(PathIntervalType p_interval_type) {
 	path_interval_type = p_interval_type;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -3804,7 +3876,9 @@ CSGPolygon3D::PathIntervalType CSGPolygon3D::get_path_interval_type() const {
 
 void CSGPolygon3D::set_path_interval(float p_interval) {
 	path_interval = p_interval;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -3814,7 +3888,9 @@ float CSGPolygon3D::get_path_interval() const {
 
 void CSGPolygon3D::set_path_simplify_angle(float p_angle) {
 	path_simplify_angle = p_angle;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -3824,7 +3900,9 @@ float CSGPolygon3D::get_path_simplify_angle() const {
 
 void CSGPolygon3D::set_path_rotation(PathRotation p_rotation) {
 	path_rotation = p_rotation;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -3834,7 +3912,9 @@ CSGPolygon3D::PathRotation CSGPolygon3D::get_path_rotation() const {
 
 void CSGPolygon3D::set_path_rotation_accurate(bool p_enabled) {
 	path_rotation_accurate = p_enabled;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -3844,6 +3924,7 @@ bool CSGPolygon3D::get_path_rotation_accurate() const {
 
 void CSGPolygon3D::set_path_local(bool p_enable) {
 	path_local = p_enable;
+	resize_brush_rework();
 	_make_painted();
 	update_gizmos();
 }
@@ -3854,7 +3935,9 @@ bool CSGPolygon3D::is_path_local() const {
 
 void CSGPolygon3D::set_path_joined(bool p_enable) {
 	path_joined = p_enable;
-	_make_painted();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1101,6 +1101,145 @@ void CSGShape3D::rebuild_brush() {
 	_make_dirty();
 }
 
+Dictionary CSGShape3D::get_csg_brush() {
+	Dictionary p_brush_data;
+	p_brush_data["painted"] = painted;
+
+	if (!brush) {
+		return p_brush_data;
+	}
+
+	if (is_root_shape()) {
+		return p_brush_data;
+	}
+
+	if (!painted) {
+		// Only save painted brushes.
+		return p_brush_data;
+	}
+
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return p_brush_data;
+	}
+
+	if (n->faces.size() <= 0) {
+		return p_brush_data;
+	}
+
+	Vector<Vector3> vertices;
+	Vector<Vector2> uvs;
+	Vector<uint8_t> smooths;
+	Vector<uint8_t> mat_id;
+	Array materials;
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		for (int j = 0; j < 3; j++) {
+			vertices.push_back(n->faces[i].vertices[j]);
+			uvs.push_back(n->faces[i].uvs[j]);
+		}
+
+		smooths.push_back(n->faces[i].smooth ? 1 : 0);
+		mat_id.push_back(n->faces[i].material);
+	}
+
+	p_brush_data["vertices"] = vertices;
+	p_brush_data["uvs"] = uvs;
+	// Replace with smooth groups in the future.
+	p_brush_data["smooth"] = smooths;
+	// We will not save combined shapes.
+	p_brush_data["inverted"] = n->faces[0].invert;
+	p_brush_data["material_id"] = mat_id;
+	p_brush_data["ngons"] = n->ngons;
+
+	for (int i = 0; i < n->materials.size(); i++) {
+		materials.push_back(n->materials[i]);
+	}
+
+	p_brush_data["materials"] = materials;
+
+	return p_brush_data;
+}
+
+void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
+	if (!p_brush_data.has("painted")) {
+		// Rebuild brush.
+		ERR_PRINT("Node doesn't have a valid _csg_brush Dictionary");
+		return;
+	}
+
+	if (!p_brush_data["painted"]) {
+		// Brush has not been modified or is root shape. Rebuild brush.
+		dirty = true;
+		return;
+	}
+
+	ERR_FAIL_COND(!p_brush_data.has("material_id"));
+	ERR_FAIL_COND(!p_brush_data.has("vertices"));
+	ERR_FAIL_COND(!p_brush_data.has("uvs"));
+	ERR_FAIL_COND(!p_brush_data.has("smooth"));
+	ERR_FAIL_COND(!p_brush_data.has("inverted"));
+	ERR_FAIL_COND(!p_brush_data.has("materials"));
+
+	painted = p_brush_data["painted"];
+
+	CSGBrush *n = memnew(CSGBrush);
+
+	Vector<uint8_t> mat_id = p_brush_data["material_id"];
+
+	int face_count = mat_id.size();
+
+	Vector<Vector3> faces = p_brush_data["vertices"];
+	Vector<Vector2> uvs = p_brush_data["uvs"];
+	Vector<bool> smooth;
+	Vector<Ref<Material>> materials;
+	Vector<bool> invert;
+
+	smooth.resize(face_count);
+	materials.resize(face_count);
+	invert.resize(face_count);
+
+	{
+		bool invrt = p_brush_data["inverted"];
+		Vector<uint8_t> smooth_i = p_brush_data["smooth"];
+		Array mats = p_brush_data["materials"];
+
+		bool *smoothw = smooth.ptrw();
+		Ref<Material> *materialsw = materials.ptrw();
+		bool *invertw = invert.ptrw();
+
+		for (int i = 0; i < face_count; i++) {
+			smoothw[i] = smooth_i[i] > 0;
+			int i_mat = mat_id[i];
+			if (i_mat < mats.size()) {
+				Ref<Material> t_mat = mats[i_mat];
+				if (t_mat.is_valid()) {
+					materialsw[i] = t_mat;
+				} else {
+					materialsw[i] = nullptr;
+				}
+			}
+			invertw[i] = invrt;
+		}
+	}
+
+	n->build_from_faces(faces, uvs, smooth, materials, invert);
+
+	if (p_brush_data.has("ngons")) {
+		n->add_ngons(p_brush_data["ngons"]);
+	} else {
+		WARN_PRINT("Resource doesn't have ngon data");
+	}
+
+	if (brush) {
+		memdelete(brush);
+	}
+
+	brush = n;
+
+	dirty = false;
+}
+
 void CSGShape3D::set_uv_offsets(const Vector<int> &p_faces, const Vector2 &prev_offset, const Vector2 &p_offset) {
 	// Use the offset obtained from `get_uv_offsets` when selecting faces.
 	CSGBrush *n = _get_brush();
@@ -1492,15 +1631,13 @@ bool CSGShape3D::resize_brush(const Vector3 &prev_size, const Vector3 &p_size) {
 	return true;
 }
 
-void CSGShape3D::set_csg_invert() {
+void CSGShape3D::set_csg_invert(bool inv_val) {
 	CSGBrush *n = _get_brush();
 	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
 	if (n->faces.is_empty()) {
 		return;
 	}
-
-	bool inv_val = get_flip_faces();
 
 	for (int i = 0; i < n->faces.size(); i++) {
 		n->faces.write[i].invert = inv_val;
@@ -1799,6 +1936,8 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_calculating_tangents"), &CSGShape3D::is_calculating_tangents);
 
 	ClassDB::bind_method(D_METHOD("rebuild_brush"), &CSGShape3D::rebuild_brush);
+	ClassDB::bind_method(D_METHOD("set_csg_brush", "csg_brush"), &CSGShape3D::set_csg_brush);
+	ClassDB::bind_method(D_METHOD("get_csg_brush"), &CSGShape3D::get_csg_brush);
 	ClassDB::bind_method(D_METHOD("set_uv_offsets", "faces", "prev_offset", "p_offset"), &CSGShape3D::set_uv_offsets);
 	ClassDB::bind_method(D_METHOD("get_uv_offsets", "face"), &CSGShape3D::get_uv_offsets);
 	ClassDB::bind_method(D_METHOD("set_uv_scale", "faces", "prev_scale", "p_scale"), &CSGShape3D::set_uv_scale);
@@ -1832,6 +1971,7 @@ void CSGShape3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autosmooth"), "set_autosmooth", "is_autosmooth");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "smoothing_angle", PROPERTY_HINT_RANGE, "0,180,0.1,degrees"), "set_smoothing_angle", "get_smoothing_angle");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_csg_brush", PROPERTY_HINT_NO_NODEPATH, "", PROPERTY_USAGE_NO_EDITOR), "set_csg_brush", "get_csg_brush");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "operation", PROPERTY_HINT_ENUM, "Union,Intersection,Subtraction"), "set_operation", "get_operation");
 #ifndef DISABLE_DEPRECATED
@@ -1904,11 +2044,7 @@ void CSGPrimitive3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_flip_faces", "flip_faces"), &CSGPrimitive3D::set_flip_faces);
 	ClassDB::bind_method(D_METHOD("get_flip_faces"), &CSGPrimitive3D::get_flip_faces);
 
-	ClassDB::bind_method(D_METHOD("set_csg_brush", "csg_brush"), &CSGPrimitive3D::set_csg_brush);
-	ClassDB::bind_method(D_METHOD("get_csg_brush"), &CSGPrimitive3D::get_csg_brush);
-
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_faces"), "set_flip_faces", "get_flip_faces");
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_csg_brush", PROPERTY_HINT_NO_NODEPATH, "", PROPERTY_USAGE_NO_EDITOR), "set_csg_brush", "get_csg_brush");
 }
 
 void CSGPrimitive3D::set_flip_faces(bool p_invert) {
@@ -1919,7 +2055,7 @@ void CSGPrimitive3D::set_flip_faces(bool p_invert) {
 	flip_faces = p_invert;
 
 	if ((is_painted() && p_invert) || (!is_root_shape() && is_inside_tree())) {
-		set_csg_invert();
+		set_csg_invert(flip_faces);
 	}
 
 	_make_painted();
@@ -1927,143 +2063,6 @@ void CSGPrimitive3D::set_flip_faces(bool p_invert) {
 
 bool CSGPrimitive3D::get_flip_faces() {
 	return flip_faces;
-}
-
-Dictionary CSGPrimitive3D::get_csg_brush() {
-	Dictionary p_brush_data;
-	p_brush_data["painted"] = painted;
-
-	if (!brush) {
-		return p_brush_data;
-	}
-
-	if (is_root_shape()) {
-		return p_brush_data;
-	}
-
-	if (!painted) {
-		// Only save painted brushes.
-		return p_brush_data;
-	}
-
-	CSGBrush *n = _get_brush();
-	if (n == nullptr) {
-		return p_brush_data;
-	}
-
-	if (n->faces.size() <= 0) {
-		return p_brush_data;
-	}
-
-	Vector<Vector3> vertices;
-	Vector<Vector2> uvs;
-	Vector<uint8_t> smooths;
-	Vector<uint8_t> mat_id;
-	Array materials;
-
-	for (int i = 0; i < n->faces.size(); i++) {
-		for (int j = 0; j < 3; j++) {
-			vertices.push_back(n->faces[i].vertices[j]);
-			uvs.push_back(n->faces[i].uvs[j]);
-		}
-
-		smooths.push_back(n->faces[i].smooth ? 1 : 0);
-		mat_id.push_back(n->faces[i].material);
-	}
-
-	p_brush_data["vertices"] = vertices;
-	p_brush_data["uvs"] = uvs;
-	// Replace with smooth groups in the future.
-	p_brush_data["smooth"] = smooths;
-	// We will not save combined shapes.
-	p_brush_data["material_id"] = mat_id;
-	p_brush_data["ngons"] = n->ngons;
-
-	for (int i = 0; i < n->materials.size(); i++) {
-		materials.push_back(n->materials[i]);
-	}
-
-	p_brush_data["materials"] = materials;
-
-	return p_brush_data;
-}
-
-void CSGPrimitive3D::set_csg_brush(const Dictionary &p_brush_data) {
-	if (!p_brush_data.has("painted")) {
-		// Rebuild brush.
-		ERR_PRINT("Node doesn't have a valid _csg_brush Dictionary");
-		return;
-	}
-
-	if (!p_brush_data["painted"]) {
-		// Brush has not been modified or is root shape. Rebuild brush.
-		dirty = true;
-		return;
-	}
-
-	ERR_FAIL_COND(!p_brush_data.has("material_id"));
-	ERR_FAIL_COND(!p_brush_data.has("vertices"));
-	ERR_FAIL_COND(!p_brush_data.has("uvs"));
-	ERR_FAIL_COND(!p_brush_data.has("smooth"));
-	ERR_FAIL_COND(!p_brush_data.has("materials"));
-
-	painted = p_brush_data["painted"];
-
-	CSGBrush *n = memnew(CSGBrush);
-
-	Vector<uint8_t> mat_id = p_brush_data["material_id"];
-
-	int face_count = mat_id.size();
-
-	Vector<Vector3> faces = p_brush_data["vertices"];
-	Vector<Vector2> uvs = p_brush_data["uvs"];
-	Vector<bool> smooth;
-	Vector<Ref<Material>> materials;
-	Vector<bool> invert;
-
-	smooth.resize(face_count);
-	materials.resize(face_count);
-	invert.resize(face_count);
-
-	{
-		bool invrt = get_flip_faces();
-		Vector<uint8_t> smooth_i = p_brush_data["smooth"];
-		Array mats = p_brush_data["materials"];
-
-		bool *smoothw = smooth.ptrw();
-		Ref<Material> *materialsw = materials.ptrw();
-		bool *invertw = invert.ptrw();
-
-		for (int i = 0; i < face_count; i++) {
-			smoothw[i] = smooth_i[i] > 0;
-			int i_mat = mat_id[i];
-			if (i_mat < mats.size()) {
-				Ref<Material> t_mat = mats[i_mat];
-				if (t_mat.is_valid()) {
-					materialsw[i] = t_mat;
-				} else {
-					materialsw[i] = nullptr;
-				}
-			}
-			invertw[i] = invrt;
-		}
-	}
-
-	n->build_from_faces(faces, uvs, smooth, materials, invert);
-
-	if (p_brush_data.has("ngons")) {
-		n->add_ngons(p_brush_data["ngons"]);
-	} else {
-		WARN_PRINT("Resource doesn't have ngon data");
-	}
-
-	if (brush) {
-		memdelete(brush);
-	}
-
-	brush = n;
-
-	dirty = false;
 }
 
 CSGPrimitive3D::CSGPrimitive3D() {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -272,7 +272,7 @@ void CSGShape3D::_make_painted(bool p_paint) {
 	} else if (!is_root_shape()) {
 		painted = painted || p_paint;
 		if (!painted && !p_paint) {
-			_make_dirty;
+			_make_dirty();
 			return;
 		}
 		notify_property_list_changed();
@@ -284,7 +284,7 @@ void CSGShape3D::_make_painted(bool p_paint) {
 	}
 }
 
-void _allow_editing() {
+void CSGShape3D::_allow_editing() {
 	first_go = false;
 }
 
@@ -503,38 +503,6 @@ struct ManifoldOperation {
 			manifold(m), operation(op) {}
 };
 
-static void _recursive_manifold(
-		std::vector<manifold::Manifold> &p_manifolds,
-		manifold::OpType &p_current_op,
-		HashMap<int32_t, Ref<Material>> &p_mesh_materials,
-		CSGShape3D *p_csg_shape) {
-	for (int i = 0; i < p_csg_shape->get_child_count(); i++) {
-		CSGShape3D *child = Object::cast_to<CSGShape3D>(p_csg_shape->get_child(i));
-		if (!child || !child->is_visible()) {
-			continue;
-		}
-		CSGBrush *child_brush = child->_get_brush();
-		if (!child_brush) {
-			continue;
-		}
-		CSGBrush transformed_brush;
-		transformed_brush.copy_from(*child_brush, child->get_transform());
-		manifold::Manifold child_manifold;
-		_pack_manifold(&transformed_brush, child_manifold, p_mesh_materials, child);
-		manifold::OpType child_operation = ManifoldOperation::convert_csg_op(child->get_operation());
-		if (child_operation != p_current_op) {
-			manifold::Manifold result = manifold::Manifold::BatchBoolean(p_manifolds, p_current_op);
-			p_manifolds.clear();
-			p_manifolds.push_back(result);
-			p_current_op = child_operation;
-		}
-		p_manifolds.push_back(child_manifold);
-		if (child->get_child_count() > 0) {
-			_recursive_manifold(p_manifolds, p_current_op, p_mesh_materials, child);
-		}
-	}
-}
-
 CSGBrush *CSGShape3D::_get_brush() {
 	if (!dirty) {
 		return brush;
@@ -573,9 +541,7 @@ CSGBrush *CSGShape3D::_get_brush() {
 				current_op = child_operation;
 			}
 			manifolds.push_back(child_manifold);
-			if (child->get_child_count() > 0) {
-				_recursive_manifold(manifolds, current_op, mesh_materials, child);
-			}
+			// TODO Get children recursively. This is only going to work with siblings for now.
 		}
 		if (!manifolds.empty()) {
 			manifold::Manifold manifold_result = manifold::Manifold::BatchBoolean(manifolds, current_op);
@@ -1119,7 +1085,7 @@ void CSGShape3D::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
-Dictionary CSGShape3D::get_csg_brush() const {
+Dictionary CSGShape3D::get_csg_brush() {
 	Dictionary p_brush_data;
 	p_brush_data["painted"] = painted;
 
@@ -1127,7 +1093,7 @@ Dictionary CSGShape3D::get_csg_brush() const {
 		return p_brush_data;
 	}
 
-	if (is_root_shape) {
+	if (is_root_shape()) {
 		// Ideally, we want to rebuild the brush to undo any manifold operations.
 		// Changes on parents of nested shapes would be undone, it would be best if all shapes were siblings.
 		return p_brush_data;
@@ -1138,7 +1104,7 @@ Dictionary CSGShape3D::get_csg_brush() const {
 		return p_brush_data;
 	}
 
-	CSGBrush *n = brush;
+	CSGBrush *n = _get_brush();
 
 	if (n->faces.size() <= 0) {
 		return p_brush_data;
@@ -1277,18 +1243,21 @@ void CSGShape3D::set_uv_offsets(const Vector<int> &p_faces, const Vector2 &prev_
 	_make_painted(true);
 }
 
-Vector2 CSGShape3D::get_uv_offsets(int p_face) const {
+Vector2 CSGShape3D::get_uv_offsets(int p_face) {
 	if (!brush) {
 		return Vector2(0.0, 0.0);
 	}
 
-	CSGBrush *n = brush;
+	CSGBrush *n = _get_brush();
 
 	if (n->faces.is_empty()) {
-		return;
+		return Vector2(0.0, 0.0);
 	}
 
-	ERR_FAIL_INDEX(p_face, n->faces.size());
+	if (p_face > n->faces.size() || p_face < 0) {
+		return Vector2(0.0, 0.0);
+	}
+
 	Vector2 smallest = n->faces[p_face].uvs[0];
 
 	for (int j = 1; j < 3; j++) {
@@ -1316,14 +1285,14 @@ void CSGShape3D::set_uv_scale(const Vector<int> &p_faces, const Vector2 &prev_sc
 		return;
 	}
 
-	if (prev_scale == 0.0 || prev_scale == 0.0) {
+	if (prev_scale.x == 0.0 || prev_scale.y == 0.0) {
 		// We fix this mess.
-		ERR_PRINT("Scale is ZERO, rebuilding shape.")
+		ERR_PRINT("Scale is ZERO, rebuilding shape.");
 		_make_dirty();
 		return;
 	}
 
-	Vector2 offset = get_uv_offsets(p_faces);
+	Vector2 offset = get_uv_offsets(p_faces[0]);
 	Vector2 n_scale = p_scale / prev_scale;
 
 	for (int i = 0; i < p_faces.size(); i++) {
@@ -1336,19 +1305,22 @@ void CSGShape3D::set_uv_scale(const Vector<int> &p_faces, const Vector2 &prev_sc
 	_make_painted(true);
 }
 
-Vector2 CSGShape3D::get_uv_scale(int p_face) const {
+Vector2 CSGShape3D::get_uv_scale(int p_face) {
 	if (!brush) {
 		return Vector2(1.0, 1.0);
 	}
 
-	CSGBrush *n = brush;
+	CSGBrush *n = _get_brush();
 
 	if (n->faces.is_empty()) {
-		return;
+		return Vector2(1.0, 1.0);
 	}
 
 	Vector2 offset = get_uv_offsets(p_face);
-	ERR_FAIL_INDEX(p_face, n->faces.size());
+	if (p_face > n->faces.size() || p_face < 0) {
+		return Vector2(1.0, 1.0);
+	}
+
 	Vector2 largest = n->faces[p_face].uvs[0] - offset;
 	largest.x = Math::abs(largest.x);
 	largest.y = Math::abs(largest.y);
@@ -1435,7 +1407,7 @@ bool CSGShape3D::resize_brush(const Vector3 &prev_size, const Vector3 &p_size) {
 		return false;
 	}
 
-	CSGBrush *n = brush;
+	CSGBrush *n = _get_brush();
 
 	if (n->faces.is_empty()) {
 		return false;
@@ -1455,7 +1427,7 @@ bool CSGShape3D::resize_brush(const Vector3 &prev_size, const Vector3 &p_size) {
 
 void set_csg_flat(bool p_mode) {
 	// This changes all faces so it can't be used with CSGCylinder3D.
-	CSGBrush *n = brush;
+	CSGBrush *n = _get_brush();
 
 	if (n->faces.is_empty()) {
 		return;
@@ -1484,8 +1456,8 @@ void CSGShape3D::set_face_material(const Vector<int> &p_faces, const Ref<Materia
 		}
 		if (find_mat == -2) {
 			// TODO Replace unused materials.
-			find_mat = materials.size();
-			materials.push_back(p_material);
+			find_mat = n->materials.size();
+			n->materials.push_back(p_material);
 		}
 	} else {
 		find_mat = -1;
@@ -1500,15 +1472,18 @@ void CSGShape3D::set_face_material(const Vector<int> &p_faces, const Ref<Materia
 	_make_painted(true);
 }
 
-Ref<Material> CSGShape3D::get_face_material(int p_face) const {
+Ref<Material> CSGShape3D::get_face_material(int p_face) {
 	// Using only one face as only one material will be returned.
-	CSGBrush *n = brush;
+	CSGBrush *n = _get_brush();
 
 	if (n->faces.is_empty()) {
 		return nullptr;
 	}
 
-	ERR_FAIL_INDEX(p_face, n->faces.size());
+	if (p_face > n->faces.size() || p_face < 0) {
+		return nullptr;
+	}
+
 	int mat = n->faces[p_face].material;
 	if (mat < 0) {
 		// mat can be -1
@@ -1517,9 +1492,9 @@ Ref<Material> CSGShape3D::get_face_material(int p_face) const {
 	return n->materials[mat];
 }
 
-Vector<Vector3> CSGShape3D::get_vertices() const {
+Vector<Vector3> CSGShape3D::get_vertices() {
 	// Use this for making a vertex editor.
-	CSGBox3D *n = brush;
+	CSGBox3D *n = _get_brush();
 
 	Vector<Vector3> vertices;
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1942,6 +1942,7 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_calculating_tangents"), &CSGShape3D::is_calculating_tangents);
 
 	ClassDB::bind_method(D_METHOD("rebuild_brush"), &CSGShape3D::rebuild_brush);
+	ClassDB::bind_method(D_METHOD("brush_modified"), &CSGShape3D::brush_modified);
 	ClassDB::bind_method(D_METHOD("set_csg_brush", "csg_brush"), &CSGShape3D::set_csg_brush);
 	ClassDB::bind_method(D_METHOD("get_csg_brush"), &CSGShape3D::get_csg_brush);
 	ClassDB::bind_method(D_METHOD("set_uv_offsets", "faces", "prev_offset", "p_offset"), &CSGShape3D::set_uv_offsets);
@@ -1952,6 +1953,7 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("flip_x", "faces"), &CSGShape3D::flip_x);
 	ClassDB::bind_method(D_METHOD("flip_y", "faces"), &CSGShape3D::flip_y);
 	ClassDB::bind_method(D_METHOD("calculate_cube_map", "faces"), &CSGShape3D::calculate_cube_map);
+	ClassDB::bind_method(D_METHOD("calculate_cylinder_map", "faces"), &CSGShape3D::calculate_cylinder_map);
 	ClassDB::bind_method(D_METHOD("set_csg_face_smooth_group", "faces", "smooth"), &CSGShape3D::set_csg_face_smooth_group);
 	ClassDB::bind_method(D_METHOD("get_csg_face_smooth_group", "face"), &CSGShape3D::get_csg_face_smooth_group);
 	ClassDB::bind_method(D_METHOD("set_face_material", "faces", "material"), &CSGShape3D::set_face_material);
@@ -2052,7 +2054,7 @@ void CSGPrimitive3D::set_flip_faces(bool p_invert) {
 
 	flip_faces = p_invert;
 
-	if ((is_painted() && p_invert) || (!is_root_shape() && is_inside_tree())) {
+	if (!is_root_shape() && is_inside_tree()) {
 		set_csg_invert(flip_faces);
 	}
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1496,7 +1496,7 @@ void CSGShape3D::set_face_material(const Vector<int> &p_faces, const Ref<Materia
 			bool is_material_used = false;
 			for (int j = 0; j < n->faces.size(); j++) {
 				if (n->faces[j].material == i) {
-					minds[j] = k;
+					minds.write[j] = k;
 					is_material_used = true;
 				}
 			}
@@ -1698,7 +1698,7 @@ int CSGShape3D::get_csg_num_faces() {
 	return n->faces.size();
 }
 
-void CSGShape3D::set_csg_face_smooth(const Vector<int> &p_faces bool p_smooth) {
+void CSGShape3D::set_csg_face_smooth(const Vector<int> &p_faces, bool p_smooth) {
 	CSGBrush *n = _get_brush();
 	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
@@ -1735,6 +1735,10 @@ bool CSGShape3D::is_csg_face_smooth(int p_face) {
 	}
 
 	return n->faces[p_face].smooth;
+}
+
+bool CSGShape3D::is_painted() const {
+	return painted;
 }
 
 Array CSGShape3D::get_meshes() const {
@@ -2283,7 +2287,7 @@ void CSGSphere3D::_bind_methods() {
 
 void CSGSphere3D::set_radius(const float p_radius) {
 	ERR_FAIL_COND(p_radius <= 0);
-	if (!painted) {
+	if (!is_painted()) {
 		radius = p_radius;
 	} else if (resize_brush(Vector3(radius, radius, radius), Vector3(p_radius, p_radius, p_radius))) {
 		radius = p_radius;
@@ -2457,7 +2461,7 @@ void CSGBox3D::_bind_methods() {
 }
 
 void CSGBox3D::set_size(const Vector3 &p_size) {
-	if (!painted) {
+	if (!is_painted()) {
 		size = p_size;
 	} else if (resize_brush(size, p_size)) {
 		size = p_size;
@@ -2669,7 +2673,7 @@ void CSGCylinder3D::_bind_methods() {
 }
 
 void CSGCylinder3D::set_radius(const float p_radius) {
-	if (!painted) {
+	if (!is_painted()) {
 		radius = p_radius;
 	} else if (resize_brush(Vector3(radius, 1.0, radius), Vector3(p_radius, 1.0, p_radius))) {
 		radius = p_radius;
@@ -2683,7 +2687,7 @@ float CSGCylinder3D::get_radius() const {
 }
 
 void CSGCylinder3D::set_height(const float p_height) {
-	if (!painted) {
+	if (!is_painted()) {
 		height = p_height;
 	} else if (resize_brush(Vector3(1.0, height, 1.0), Vector3(1.0, p_height, 1.0))) {
 		height = p_height;

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -113,7 +113,7 @@ void CSGShape3D::set_use_collision(bool p_enable) {
 		set_collision_layer(collision_layer);
 		set_collision_mask(collision_mask);
 		set_collision_priority(collision_priority);
-		_make_dirty(); //force update
+		_make_painted(); //force update
 	} else {
 		PhysicsServer3D::get_singleton()->free_rid(root_collision_instance);
 		root_collision_instance = RID();
@@ -246,7 +246,6 @@ float CSGShape3D::get_snap() const {
 #endif // DISABLE_DEPRECATED
 
 void CSGShape3D::_make_dirty(bool p_parent_removing) {
-	painted = false;
 #ifndef PHYSICS_3D_DISABLED
 	if ((p_parent_removing || is_root_shape()) && !dirty) {
 		callable_mp(this, &CSGShape3D::update_shape).call_deferred(); // Must be deferred; otherwise, is_root_shape() will use the previous parent.
@@ -262,19 +261,21 @@ void CSGShape3D::_make_dirty(bool p_parent_removing) {
 	}
 #endif // PHYSICS_3D_DISABLED
 
+	painted = false;
 	dirty = true;
 	notify_property_list_changed();
 }
 
 void CSGShape3D::_make_painted(bool p_paint, bool p_parent_removing) {
 	if (p_parent_removing) {
-		// Why won't you work?
 		callable_mp(this, &CSGShape3D::update_shape).call_deferred();
-	} else if (!brush) {
-		_make_dirty();
 	} else if (!is_root_shape()) {
+		// The !is_root_shape() means the node has a parent so it has been added already.
 		painted = painted || p_paint;
 		if (!painted) {
+			_make_dirty();
+			return;
+		} else if (!brush) {
 			_make_dirty();
 			return;
 		}
@@ -282,8 +283,11 @@ void CSGShape3D::_make_painted(bool p_paint, bool p_parent_removing) {
 		// We force a rebuild of the root shape only.
 		parent_shape->_make_painted();
 	} else {
-		// With this we can replace most calls to _make_dirty().
-		_make_dirty();
+		// I have a theory the bug happens because properties are set before add_child, so the node is root shape because it doesn't have a parent.
+		if (is_inside_tree()) {
+			// With this we can replace most calls to _make_dirty().
+			_make_dirty();
+		}
 	}
 }
 
@@ -1008,7 +1012,7 @@ void CSGShape3D::_notification(int p_what) {
 				set_collision_mask(collision_mask);
 				set_collision_priority(collision_priority);
 				debug_shape_old_transform = get_global_transform();
-				_make_dirty();
+				_make_painted();
 			}
 		} break;
 
@@ -1216,7 +1220,6 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 	brush = n;
 
 	dirty = false;
-	_make_painted(true);
 }
 
 void CSGShape3D::rebuild_brush() {
@@ -1469,7 +1472,6 @@ void CSGShape3D::set_face_material(const Vector<int> &p_faces, const Ref<Materia
 			}
 		}
 		if (find_mat == -2) {
-			// TODO Remove unused materials.
 			find_mat = n->materials.size();
 			n->materials.push_back(p_material);
 		}
@@ -1615,7 +1617,7 @@ void CSGShape3D::calculate_cube_map(const Vector<int> &p_faces) {
 			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(mir_x * v3.z, v3.y));
 		} else if (nor.y > nor.z) {
 			// Direction Y, XZ.
-			float mir_x = ang.normal.y < 0.0 ? -1.0 : 0.0;
+			float mir_x = ang.normal.y < 0.0 ? -1.0 : 1.0;
 			n->faces.write[p].uvs[0] = Vector2(mir_x * v1.x, v1.z);
 			n->faces.write[p].uvs[1] = Vector2(mir_x * v2.x, v2.z);
 			n->faces.write[p].uvs[2] = Vector2(mir_x * v3.x, v3.z);
@@ -1737,6 +1739,15 @@ bool CSGShape3D::is_painted() const {
 	return painted;
 }
 
+Vector<int> CSGShape3D::get_all_csg_faces() const {
+	Vector<int> all_faces;
+	all_faces.resize(get_csg_num_faces());
+	for (int i = 0; i < all_faces.size(); i++) {
+		all_faces.write[i] = i;
+	}
+	return all_faces;
+}
+
 Array CSGShape3D::get_meshes() const {
 	if (root_mesh.is_valid()) {
 		Array arr;
@@ -1828,6 +1839,8 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_selected_faces", "faces"), &CSGShape3D::get_selected_faces);
 	ClassDB::bind_method(D_METHOD("get_csg_faces_anchor_points"), &CSGShape3D::get_csg_faces_anchor_points);
 	ClassDB::bind_method(D_METHOD("get_csg_num_faces"), &CSGShape3D::get_csg_num_faces);
+	ClassDB::bind_method(D_METHOD("set_csg_face_smooth", "faces", "smooth"), &CSGShape3D::set_csg_face_smooth);
+	ClassDB::bind_method(D_METHOD("is_csg_face_smooth", "face"), &CSGShape3D::is_csg_face_smooth);
 
 	ClassDB::bind_method(D_METHOD("get_meshes"), &CSGShape3D::get_meshes);
 
@@ -2087,7 +2100,7 @@ void CSGMesh3D::set_material(const Ref<Material> &p_material) {
 		return;
 	}
 	material = p_material;
-	_make_painted();
+	set_face_material(get_all_csg_faces(), material);
 }
 
 Ref<Material> CSGMesh3D::get_material() const {
@@ -2328,7 +2341,7 @@ bool CSGSphere3D::get_smooth_faces() const {
 
 void CSGSphere3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	_make_painted();
+	set_face_material(get_all_csg_faces(), material)
 }
 
 Ref<Material> CSGSphere3D::get_material() const {
@@ -2496,7 +2509,7 @@ bool CSGBox3D::_set(const StringName &p_name, const Variant &p_value) {
 
 void CSGBox3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	_make_painted();
+	set_face_material(get_all_csg_faces(), material)
 	update_gizmos();
 }
 
@@ -2728,7 +2741,7 @@ bool CSGCylinder3D::get_smooth_faces() const {
 
 void CSGCylinder3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	_make_painted();
+	set_face_material(get_all_csg_faces(), material)
 }
 
 Ref<Material> CSGCylinder3D::get_material() const {
@@ -2955,7 +2968,7 @@ bool CSGTorus3D::get_smooth_faces() const {
 
 void CSGTorus3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	_make_painted();
+	set_face_material(get_all_csg_faces(), material)
 }
 
 Ref<Material> CSGTorus3D::get_material() const {
@@ -3615,7 +3628,7 @@ bool CSGPolygon3D::get_smooth_faces() const {
 
 void CSGPolygon3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	_make_painted();
+	set_face_material(get_all_csg_faces(), material)
 }
 
 Ref<Material> CSGPolygon3D::get_material() const {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -266,8 +266,11 @@ void CSGShape3D::_make_dirty(bool p_parent_removing) {
 	notify_property_list_changed();
 }
 
-void CSGShape3D::_make_painted(bool p_paint) {
-	if (!brush) {
+void CSGShape3D::_make_painted(bool p_paint, bool p_parent_removing) {
+	if (p_parent_removing) {
+		// Why won't you work?
+		callable_mp(this, &CSGShape3D::update_shape).call_deferred();
+	} else if (!brush) {
 		_make_dirty();
 	} else if (!is_root_shape()) {
 		if (!painted && !p_paint) {
@@ -512,7 +515,9 @@ CSGBrush *CSGShape3D::_get_brush() {
 		// CSG tree must iterate over all shapes, but we gain the ability to edit parent brushes and save them in their base form.
 		HashMap<int32_t, Ref<Material>> mesh_materials;
 		manifold::Manifold root_manifold;
-		_pack_manifold(n, root_manifold, mesh_materials, this);
+		CSGBrush trans_root;
+		trans_root.copy_from(*n, get_global_transform());
+		_pack_manifold(&trans_root, root_manifold, mesh_materials, this);
 		manifold::OpType current_op = ManifoldOperation::convert_csg_op(get_operation());
 		std::vector<manifold::Manifold> manifolds;
 		manifolds.push_back(root_manifold);
@@ -525,7 +530,7 @@ CSGBrush *CSGShape3D::_get_brush() {
 				continue;
 			}
 			CSGBrush transformed_brush;
-			transformed_brush.copy_from(*child_brush, child->get_transform());
+			transformed_brush.copy_from(*child_brush, child->get_global_transform()); // Changing this to global for nested nodes. We now need to transform the root shape too.
 			manifold::Manifold child_manifold;
 			_pack_manifold(&transformed_brush, child_manifold, mesh_materials, child);
 			manifold::OpType child_operation = ManifoldOperation::convert_csg_op(child->get_operation());
@@ -960,9 +965,6 @@ void CSGShape3D::_notification(int p_what) {
 			}
 			if (parent_shape) {
 				_make_painted();
-			} else if (!brush) {
-				// Update this node if uninitialized, or both this node and its new parent if it gets added to another CSG shape
-				_make_dirty();
 			}
 			last_visible = is_visible();
 		} break;
@@ -971,7 +973,7 @@ void CSGShape3D::_notification(int p_what) {
 			if (!is_root_shape()) {
 				// Update this node and its previous parent only if it's currently being removed from another CSG shape
 				// TODO investigate.
-				_make_dirty(true); // Must be forced since is_root_shape() uses the previous parent
+				_make_painted(false, true); // Must be forced since is_root_shape() uses the previous parent
 			}
 			parent_shape = nullptr;
 		} break;
@@ -1218,6 +1220,7 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 	brush = n;
 
 	dirty = false;
+	_make_painted(true);
 }
 
 void CSGShape3D::rebuild_brush() {
@@ -1406,6 +1409,15 @@ void CSGShape3D::flip_y(const Vector<int> &p_faces) {
 }
 
 bool CSGShape3D::resize_brush(const Vector3 &prev_size, const Vector3 &p_size) {
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return true;
+	}
+
+	if (n->faces.is_empty()) {
+		return false;
+	}
+
 	if (prev_size.x == 0.0 || prev_size.y == 0.0 || prev_size.z == 0.0) {
 		ERR_PRINT("size can NEVER be ZERO!");
 		_make_dirty();
@@ -1414,15 +1426,6 @@ bool CSGShape3D::resize_brush(const Vector3 &prev_size, const Vector3 &p_size) {
 
 	if (p_size.x == 0.0 || p_size.y == 0.0 || p_size.z == 0.0) {
 		ERR_PRINT("size can NEVER be ZERO");
-		return false;
-	}
-
-	CSGBrush *n = _get_brush();
-	if (n == nullptr) {
-		return true;
-	}
-
-	if (n->faces.is_empty()) {
 		return false;
 	}
 
@@ -1483,6 +1486,40 @@ void CSGShape3D::set_face_material(const Vector<int> &p_faces, const Ref<Materia
 		ERR_FAIL_INDEX(p, n->faces.size());
 		n->faces.write[p].material = find_mat;
 	}
+
+	{
+		Vector<Ref<Material>> nmats;
+		Vector<int> minds;
+		minds.resize(n->faces.size());
+		int k = 0;
+		for (int i = 0; i < n->materials.size(); i++) {
+			bool is_material_used = false;
+			for (int j = 0; j < n->faces.size(); j++) {
+				if (n->faces[j].material == i) {
+					minds[j] = k;
+					is_material_used = true;
+				}
+			}
+			if (is_material_used) {
+				nmats.push_back(n->materials[i]);
+				k++;
+			}
+		}
+
+		for (int i = 0; i < n->faces.size(); i++) {
+			if (n->faces[i].material == -1) {
+				n->faces.write[i].material = -1;
+			} else {
+				n->faces.write[i].material = minds[i];
+			}
+		}
+
+		n->materials.resize(nmats.size());
+		for (int i = 0; i < nmats.size(); i++) {
+			n->materials.write[i] = nmats[i];
+		}
+	}
+
 	// TODO make a different method for setting material for the whole shape.
 	_make_painted(true);
 }
@@ -1560,6 +1597,9 @@ void CSGShape3D::calculate_cube_map(const Vector<int> &p_faces) {
 		return;
 	}
 
+	// 3D goes bot to top while 2D goes top to bottom.
+	Transform2D p_rotation = Transform2D(Math::deg_to_rad(180.0), Vector2(0.0, 0.0));
+
 	for (int i = 0; i < p_faces.size(); i++) {
 		int p = p_faces[i];
 		ERR_FAIL_INDEX(p, n->faces.size());
@@ -1573,19 +1613,22 @@ void CSGShape3D::calculate_cube_map(const Vector<int> &p_faces) {
 
 		if (nor.x > nor.y && nor.x > nor.z) {
 			// Direction X, ZY.
-			n->faces.write[p].uvs[0] = Vector2(v1.z, v1.y);
-			n->faces.write[p].uvs[1] = Vector2(v2.z, v2.y);
-			n->faces.write[p].uvs[2] = Vector2(v3.z, v3.y);
+			float mir_x = ang.normal.x < 0.0 ? -1.0 : 0.0;
+			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(mir_x * v1.z, v1.y));
+			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(mir_x * v2.z, v2.y));
+			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(mir_x * v3.z, v3.y));
 		} else if (nor.y > nor.z) {
 			// Direction Y, XZ.
-			n->faces.write[p].uvs[0] = Vector2(v1.x, v1.z);
-			n->faces.write[p].uvs[1] = Vector2(v2.x, v2.z);
-			n->faces.write[p].uvs[2] = Vector2(v3.x, v3.z);
+			float mir_x = ang.normal.y < 0.0 ? -1.0 : 0.0;
+			n->faces.write[p].uvs[0] = Vector2(mir_x * v1.x, v1.z);
+			n->faces.write[p].uvs[1] = Vector2(mir_x * v2.x, v2.z);
+			n->faces.write[p].uvs[2] = Vector2(mir_x * v3.x, v3.z);
 		} else {
 			// Direction Z, XY.
-			n->faces.write[p].uvs[0] = Vector2(v1.x, v1.y);
-			n->faces.write[p].uvs[1] = Vector2(v2.x, v2.y);
-			n->faces.write[p].uvs[2] = Vector2(v3.x, v3.y);
+			float mir_x = ang.normal.z < 0.0 ? -1.0 : 0.0;
+			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(mir_x * v1.x, v1.y));
+			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(mir_x * v2.x, v2.y));
+			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(mir_x * v3.x, v3.y));
 		}
 	}
 	_make_painted(true);
@@ -1608,6 +1651,7 @@ Vector<Vector3> CSGShape3D::get_selected_faces(const Vector<int> &p_faces) {
 	for (int i = 0; i < p_faces.size(); i++) {
 		int p = p_faces[i];
 		if (p > n->faces.size() || p < 0) {
+			ERR_PRINT("Invalid face in p_faces");
 			continue;
 		}
 		for (int j = 0; j < 3; j++) {
@@ -1615,6 +1659,82 @@ Vector<Vector3> CSGShape3D::get_selected_faces(const Vector<int> &p_faces) {
 		}
 	}
 	return ret;
+}
+
+Vector<Vector3> CSGShape3D::get_csg_faces_anchor_points() {
+	// Returns the center of each face for displaying anchors. The original idea was for faces to be clicked on, but that might require too much work, and CSGs don't have that many faces anyway, fewer when ngons are implemented.
+	// This can be modified to display center of ngons in the future.
+	CSGBrush *n = _get_brush();
+
+	Vector<Vector3> ret;
+
+	if (n == nullptr) {
+		return ret;
+	}
+
+	if (n->faces.is_empty()) {
+		return ret;
+	}
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		// TODO replace with ngons.
+		Vector3 aprox_pos = Vector3(0, 0, 0);
+		for (int j = 0; j < 3; j++) {
+			aprox_pos += n->faces[i].vertices[j];
+		}
+		aprox_pos /= 3;
+		ret.push_back(aprox_pos);
+	}
+	return ret;
+}
+
+int CSGShape3D::get_csg_num_faces() {
+	CSGBrush *n = _get_brush();
+
+	if (n == nullptr) {
+		return 0;
+	}
+
+	return n->faces.size();
+}
+
+void CSGShape3D::set_csg_face_smooth(const Vector<int> &p_faces bool p_smooth) {
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			n->faces.write[p].smooth = p_smooth;
+		}
+	}
+	_make_painted(true);
+}
+
+bool CSGShape3D::is_csg_face_smooth(int p_face) {
+	if (!brush) {
+		return false;
+	}
+
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return false;
+	}
+
+	if (n->faces.is_empty()) {
+		return false;
+	}
+
+	if (p_face > n->faces.size() || p_face < 0) {
+		return false;
+	}
+
+	return n->faces[p_face].smooth;
 }
 
 Array CSGShape3D::get_meshes() const {
@@ -1706,6 +1826,8 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_vertex_position", "from", "to"), &CSGShape3D::set_vertex_position);
 	ClassDB::bind_method(D_METHOD("calculate_cube_map", "faces"), &CSGShape3D::calculate_cube_map);
 	ClassDB::bind_method(D_METHOD("get_selected_faces", "faces"), &CSGShape3D::get_selected_faces);
+	ClassDB::bind_method(D_METHOD("get_csg_faces_anchor_points"), &CSGShape3D::get_csg_faces_anchor_points);
+	ClassDB::bind_method(D_METHOD("get_csg_num_faces"), &CSGShape3D::get_csg_num_faces);
 
 	ClassDB::bind_method(D_METHOD("get_meshes"), &CSGShape3D::get_meshes);
 
@@ -2161,7 +2283,9 @@ void CSGSphere3D::_bind_methods() {
 
 void CSGSphere3D::set_radius(const float p_radius) {
 	ERR_FAIL_COND(p_radius <= 0);
-	if (resize_brush(Vector3(radius, radius, radius), Vector3(p_radius, p_radius, p_radius))) {
+	if (!painted) {
+		radius = p_radius;
+	} else if (resize_brush(Vector3(radius, radius, radius), Vector3(p_radius, p_radius, p_radius))) {
 		radius = p_radius;
 	}
 	_make_painted();
@@ -2333,7 +2457,9 @@ void CSGBox3D::_bind_methods() {
 }
 
 void CSGBox3D::set_size(const Vector3 &p_size) {
-	if (resize_brush(size, p_size)) {
+	if (!painted) {
+		size = p_size;
+	} else if (resize_brush(size, p_size)) {
 		size = p_size;
 	}
 	_make_painted();
@@ -2543,7 +2669,9 @@ void CSGCylinder3D::_bind_methods() {
 }
 
 void CSGCylinder3D::set_radius(const float p_radius) {
-	if (resize_brush(Vector3(radius, 1.0, radius), Vector3(p_radius, 1.0, p_radius))) {
+	if (!painted) {
+		radius = p_radius;
+	} else if (resize_brush(Vector3(radius, 1.0, radius), Vector3(p_radius, 1.0, p_radius))) {
 		radius = p_radius;
 	}
 	_make_painted();
@@ -2555,7 +2683,9 @@ float CSGCylinder3D::get_radius() const {
 }
 
 void CSGCylinder3D::set_height(const float p_height) {
-	if (resize_brush(Vector3(1.0, height, 1.0), Vector3(1.0, p_height, 1.0))) {
+	if (!painted) {
+		height = p_height;
+	} else if (resize_brush(Vector3(1.0, height, 1.0), Vector3(1.0, p_height, 1.0))) {
 		height = p_height;
 	}
 	_make_painted();

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1998,7 +1998,7 @@ CSGBrush *CSGPrimitive3D::_create_brush_from_arrays(const Vector<Vector3> &p_ver
 		ERR_FAIL_COND_V(!new_brush->faces.size() > 0, new_brush);
 		int ngon_counter = 0;
 		ngons.write[0] = ngon_counter;
-		Vector3 f_vert =  new_brush->faces[0].vertices[0];
+		Vector3 f_vert = new_brush->faces[0].vertices[0];
 		Vector3 l_vert = new_brush->faces[0].vertices[2];
 		for (int i = 1; i < ngons.size(); i++) {
 			if (!f_vert.is_equal_approx(new_brush->faces[i].vertices[2]) || !l_vert.is_equal_approx(new_brush->faces[i].vertices[0])) {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -333,7 +333,7 @@ static void _unpack_manifold(
 			CSGBrush::Face face;
 			face.material = material_id;
 			int32_t first_property_index = mesh.triVerts[vert_i + order[0]];
-			face.smooth = mesh.vertProperties[first_property_index * mesh.numProp + MANIFOLD_PROPERTY_SMOOTH_GROUP] > 0.5f;
+			face.smooth = static_cast<int>(mesh.vertProperties[first_property_index * mesh.numProp + MANIFOLD_PROPERTY_SMOOTH_GROUP]);
 			face.invert = mesh.vertProperties[first_property_index * mesh.numProp + MANIFOLD_PROPERTY_INVERT] > 0.5f;
 
 			for (int32_t tri_order_i = 0; tri_order_i < 3; tri_order_i++) {
@@ -471,7 +471,7 @@ static void _pack_manifold(
 				vert[MANIFOLD_PROPERTY_POSITION_Z] = face.vertices[i].z;
 				vert[MANIFOLD_PROPERTY_UV_X_0] = face.uvs[i].x;
 				vert[MANIFOLD_PROPERTY_UV_Y_0] = face.uvs[i].y;
-				vert[MANIFOLD_PROPERTY_SMOOTH_GROUP] = face.smooth ? 1.0f : 0.0f;
+				vert[MANIFOLD_PROPERTY_SMOOTH_GROUP] = face.smooth;
 				vert[MANIFOLD_PROPERTY_INVERT] = face.invert ? 1.0f : 0.0f;
 			}
 		}
@@ -691,8 +691,8 @@ void CSGShape3D::update_shape() {
 		}
 	} else {
 		for (int i = 0; i < smooth_faces.size(); i++) {
-			bool face_is_smooth = n->faces[i].smooth;
-			if (face_is_smooth) {
+			int face_is_smooth = n->faces[i].smooth;
+			if (face_is_smooth > 0) {
 				for (int k = 0; k < 3; k++) {
 					Vector3 vert_a = n->faces[i].vertices[k];
 					int curr_vert = i * 3 + k;
@@ -1139,7 +1139,7 @@ Dictionary CSGShape3D::get_csg_brush() {
 			uvs.push_back(n->faces[i].uvs[j]);
 		}
 
-		smooths.push_back(n->faces[i].smooth ? 1 : 0);
+		smooths.push_back(n->faces[i].smooth);
 		mat_id.push_back(n->faces[i].material);
 	}
 
@@ -1191,7 +1191,7 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 
 	Vector<Vector3> faces = p_brush_data["vertices"];
 	Vector<Vector2> uvs = p_brush_data["uvs"];
-	Vector<bool> smooth;
+	Vector<int> smooth;
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
@@ -1204,12 +1204,12 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 		Vector<uint8_t> smooth_i = p_brush_data["smooth"];
 		Array mats = p_brush_data["materials"];
 
-		bool *smoothw = smooth.ptrw();
+		int *smoothw = smooth.ptrw();
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
 
 		for (int i = 0; i < face_count; i++) {
-			smoothw[i] = smooth_i[i] > 0;
+			smoothw[i] = smooth_i[i];
 			int i_mat = mat_id[i];
 			if (i_mat < mats.size()) {
 				Ref<Material> t_mat = mats[i_mat];
@@ -1467,7 +1467,7 @@ void CSGShape3D::calculate_cube_map(const Vector<int> &p_faces) {
 	_make_painted(true);
 }
 
-void CSGShape3D::set_csg_face_smooth(const Vector<int> &p_faces, bool p_smooth) {
+void CSGShape3D::set_csg_face_smooth_group(const Vector<int> &p_faces, int p_smooth) {
 	CSGBrush *n = _get_brush();
 	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
@@ -1485,22 +1485,22 @@ void CSGShape3D::set_csg_face_smooth(const Vector<int> &p_faces, bool p_smooth) 
 	_make_painted(true);
 }
 
-bool CSGShape3D::is_csg_face_smooth(int p_face) {
+int CSGShape3D::get_csg_face_smooth_group(int p_face) {
 	if (!brush) {
-		return false;
+		return 0;
 	}
 
 	CSGBrush *n = _get_brush();
 	if (n == nullptr) {
-		return false;
+		return 0;
 	}
 
 	if (n->faces.is_empty()) {
-		return false;
+		return 0;
 	}
 
 	if (p_face > n->faces.size() || p_face < 0) {
-		return false;
+		return 0;
 	}
 
 	return n->faces[p_face].smooth;
@@ -1656,7 +1656,7 @@ void CSGShape3D::set_csg_flat(bool p_mode) {
 
 	// TODO Smooth groups.
 	for (int i = 0; i < n->faces.size(); i++) {
-		n->faces.write[i].smooth = p_mode;
+		n->faces.write[i].smooth = p_mode ? 1 : 0;
 	}
 }
 
@@ -1777,7 +1777,6 @@ Vector<int> CSGShape3D::get_faces_from_ngon(int p_ngon) {
 
 TypedArray<Vector<Vector3>> CSGShape3D::get_csg_ngon_colliders() {
 	// Returns an array of Vector<Vector3> to use to create a TriangleMesh for each collider of ngon to be used in gizmos.
-	// This could probably work better if it returns TriangleMesh, as it will be used for collision.
 	TypedArray<Vector<Vector3>> ret;
 	CSGBrush *n = _get_brush();
 
@@ -1975,7 +1974,7 @@ CSGCombiner3D::CSGCombiner3D() {
 
 /////////////////////
 
-CSGBrush *CSGPrimitive3D::_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials) {
+CSGBrush *CSGPrimitive3D::_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<int> &p_smooth, const Vector<Ref<Material>> &p_materials) {
 	CSGBrush *new_brush = memnew(CSGBrush);
 
 	Vector<bool> invert;
@@ -2051,7 +2050,7 @@ CSGBrush *CSGMesh3D::_build_brush() {
 	}
 
 	Vector<Vector3> vertices;
-	Vector<bool> smooth;
+	Vector<int> smooth;
 	Vector<Ref<Material>> materials;
 	Vector<Vector2> uvs;
 	Ref<Material> base_material = get_material();
@@ -2105,7 +2104,7 @@ CSGBrush *CSGMesh3D::_build_brush() {
 			uvs.resize(as + is);
 
 			Vector3 *vw = vertices.ptrw();
-			bool *sw = smooth.ptrw();
+			int *sw = smooth.ptrw();
 			Vector2 *uvw = uvs.ptrw();
 			Ref<Material> *mw = materials.ptrw();
 
@@ -2137,7 +2136,7 @@ CSGBrush *CSGMesh3D::_build_brush() {
 				uvw[as + j + 1] = uv[1];
 				uvw[as + j + 2] = uv[2];
 
-				sw[(as + j) / 3] = !flat;
+				sw[(as + j) / 3] = flat ? 0 : 1;
 				mw[(as + j) / 3] = mat;
 			}
 		} else {
@@ -2150,7 +2149,7 @@ CSGBrush *CSGMesh3D::_build_brush() {
 			materials.resize((as + is) / 3);
 
 			Vector3 *vw = vertices.ptrw();
-			bool *sw = smooth.ptrw();
+			int *sw = smooth.ptrw();
 			Vector2 *uvw = uvs.ptrw();
 			Ref<Material> *mw = materials.ptrw();
 
@@ -2179,7 +2178,7 @@ CSGBrush *CSGMesh3D::_build_brush() {
 				uvw[as + j + 1] = uv[1];
 				uvw[as + j + 2] = uv[2];
 
-				sw[(as + j) / 3] = !flat;
+				sw[(as + j) / 3] = flat ? 1 : 0;
 				mw[(as + j) / 3] = mat;
 			}
 		}
@@ -2258,7 +2257,7 @@ CSGBrush *CSGSphere3D::_build_brush() {
 
 	Vector<Vector3> faces;
 	Vector<Vector2> uvs;
-	Vector<bool> smooth;
+	Vector<int> smooth;
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
@@ -2275,7 +2274,7 @@ CSGBrush *CSGSphere3D::_build_brush() {
 	{
 		Vector3 *facesw = faces.ptrw();
 		Vector2 *uvsw = uvs.ptrw();
-		bool *smoothw = smooth.ptrw();
+		int *smoothw = smooth.ptrw();
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
 		int *ngonw = ngons.ptrw();
@@ -2347,7 +2346,7 @@ CSGBrush *CSGSphere3D::_build_brush() {
 					uvsw[face * 3 + 1] = u[1];
 					uvsw[face * 3 + 2] = u[2];
 
-					smoothw[face] = smooth_faces;
+					smoothw[face] = smooth_faces ? 1 : 0;
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
 
@@ -2366,7 +2365,7 @@ CSGBrush *CSGSphere3D::_build_brush() {
 					uvsw[face * 3 + 1] = u[3];
 					uvsw[face * 3 + 2] = u[0];
 
-					smoothw[face] = smooth_faces;
+					smoothw[face] = smooth_faces ? 1 : 0;
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
 
@@ -2489,7 +2488,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 
 	Vector<Vector3> faces;
 	Vector<Vector2> uvs;
-	Vector<bool> smooth;
+	Vector<int> smooth;
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
@@ -2506,7 +2505,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 	{
 		Vector3 *facesw = faces.ptrw();
 		Vector2 *uvsw = uvs.ptrw();
-		bool *smoothw = smooth.ptrw();
+		int *smoothw = smooth.ptrw();
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
 		int *ngonw = ngons.ptrw();
@@ -2550,7 +2549,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 				uvsw[face * 3 + 1] = u[1];
 				uvsw[face * 3 + 2] = u[2];
 
-				smoothw[face] = false;
+				smoothw[face] = 0;
 				invertw[face] = invert_val;
 				materialsw[face] = base_material;
 				ngonw[face] = ngon_counter;
@@ -2565,7 +2564,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 				uvsw[face * 3 + 1] = u[3];
 				uvsw[face * 3 + 2] = u[0];
 
-				smoothw[face] = false;
+				smoothw[face] = 0;
 				invertw[face] = invert_val;
 				materialsw[face] = base_material;
 				ngonw[face] = ngon_counter;
@@ -2661,7 +2660,7 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 
 	Vector<Vector3> faces;
 	Vector<Vector2> uvs;
-	Vector<bool> smooth;
+	Vector<int> smooth;
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
@@ -2678,7 +2677,7 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 	{
 		Vector3 *facesw = faces.ptrw();
 		Vector2 *uvsw = uvs.ptrw();
-		bool *smoothw = smooth.ptrw();
+		int *smoothw = smooth.ptrw();
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
 
@@ -2726,7 +2725,7 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 				uvsw[face * 3 + 1] = u[1];
 				uvsw[face * 3 + 2] = u[2];
 
-				smoothw[face] = smooth_faces;
+				smoothw[face] = smooth_faces ? 1 : 0;
 				invertw[face] = invert_val;
 				materialsw[face] = base_material;
 
@@ -2744,7 +2743,7 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 					uvsw[face * 3 + 1] = u[3];
 					uvsw[face * 3 + 2] = u[0];
 
-					smoothw[face] = smooth_faces;
+					smoothw[face] = smooth_faces ? 1 : 0;
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
 
@@ -2764,7 +2763,7 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 				uvsw[face * 3 + 1] = Vector2(face_points[0].x, face_points[0].y) * 0.5 + Vector2(0.5, 0.5);
 				uvsw[face * 3 + 2] = Vector2(0.5, 0.5);
 
-				smoothw[face] = false;
+				smoothw[face] = 2;
 				invertw[face] = invert_val;
 				materialsw[face] = base_material;
 				ngonw[face] = 0;
@@ -2780,7 +2779,7 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 					uvsw[face * 3 + 1] = Vector2(face_points[0].x, face_points[0].y) * 0.5 + Vector2(0.5, 0.5);
 					uvsw[face * 3 + 2] = Vector2(0.5, 0.5);
 
-					smoothw[face] = false;
+					smoothw[face] = 2;
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
 					ngonw[face] = 1;
@@ -2932,7 +2931,7 @@ CSGBrush *CSGTorus3D::_build_brush() {
 
 	Vector<Vector3> faces;
 	Vector<Vector2> uvs;
-	Vector<bool> smooth;
+	Vector<int> smooth;
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
@@ -2949,7 +2948,7 @@ CSGBrush *CSGTorus3D::_build_brush() {
 	{
 		Vector3 *facesw = faces.ptrw();
 		Vector2 *uvsw = uvs.ptrw();
-		bool *smoothw = smooth.ptrw();
+		int *smoothw = smooth.ptrw();
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
 
@@ -3008,7 +3007,7 @@ CSGBrush *CSGTorus3D::_build_brush() {
 					uvsw[face * 3 + 1] = u[2];
 					uvsw[face * 3 + 2] = u[1];
 
-					smoothw[face] = smooth_faces;
+					smoothw[face] = smooth_faces ? 1 : 0;
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
 
@@ -3025,7 +3024,7 @@ CSGBrush *CSGTorus3D::_build_brush() {
 					uvsw[face * 3 + 1] = u[2];
 					uvsw[face * 3 + 2] = u[0];
 
-					smoothw[face] = smooth_faces;
+					smoothw[face] = smooth_faces ? 1 : 0;
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
 
@@ -3236,7 +3235,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 
 	Vector<Vector3> faces;
 	Vector<Vector2> uvs;
-	Vector<bool> smooth;
+	Vector<int> smooth;
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
@@ -3253,7 +3252,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 	{
 		Vector3 *facesw = faces.ptrw();
 		Vector2 *uvsw = uvs.ptrw();
-		bool *smoothw = smooth.ptrw();
+		int *smoothw = smooth.ptrw();
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
 
@@ -3339,7 +3338,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 					uvsw[face * 3 + face_vertex_idx] = uv;
 				}
 
-				smoothw[face] = false;
+				smoothw[face] = 2;
 				materialsw[face] = base_material;
 				invertw[face] = flip_faces;
 				ngonw[face] = ngon_counter;
@@ -3457,7 +3456,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 				uvsw[face * 3 + 1] = u[1];
 				uvsw[face * 3 + 2] = u[2];
 
-				smoothw[face] = smooth_faces;
+				smoothw[face] = smooth_faces ? 1 : 0;
 				invertw[face] = flip_faces;
 				materialsw[face] = base_material;
 				ngonw[face] = ngon_counter;
@@ -3473,7 +3472,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 				uvsw[face * 3 + 1] = u[3];
 				uvsw[face * 3 + 2] = u[0];
 
-				smoothw[face] = smooth_faces;
+				smoothw[face] = smooth_faces ? 1 : 0;
 				invertw[face] = flip_faces;
 				materialsw[face] = base_material;
 				ngonw[face] = ngon_counter;
@@ -3499,7 +3498,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 					uvsw[face * 3 + face_vertex_idx] = uv;
 				}
 
-				smoothw[face] = false;
+				smoothw[face] = 2;
 				materialsw[face] = base_material;
 				invertw[face] = flip_faces;
 				ngonw[face] = ngon_counter;

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -207,7 +207,7 @@ real_t CSGShape3D::get_collision_priority() const {
 
 void CSGShape3D::set_autosmooth(bool p_smooth) {
 	autosmooth = p_smooth;
-	_make_dirty();
+	_make_painted();
 	notify_property_list_changed();
 }
 
@@ -217,7 +217,7 @@ bool CSGShape3D::is_autosmooth() const {
 
 void CSGShape3D::set_smoothing_angle(const float p_angle) {
 	smoothing_angle = p_angle;
-	_make_dirty();
+	_make_painted();
 }
 
 float CSGShape3D::get_smoothing_angle() const {
@@ -237,7 +237,7 @@ void CSGShape3D::set_snap(float p_snap) {
 	}
 
 	snap = p_snap;
-	_make_dirty();
+	_make_painted();
 }
 
 float CSGShape3D::get_snap() const {
@@ -246,6 +246,7 @@ float CSGShape3D::get_snap() const {
 #endif // DISABLE_DEPRECATED
 
 void CSGShape3D::_make_dirty(bool p_parent_removing) {
+	painted = false;
 #ifndef PHYSICS_3D_DISABLED
 	if ((p_parent_removing || is_root_shape()) && !dirty) {
 		callable_mp(this, &CSGShape3D::update_shape).call_deferred(); // Must be deferred; otherwise, is_root_shape() will use the previous parent.
@@ -253,7 +254,7 @@ void CSGShape3D::_make_dirty(bool p_parent_removing) {
 #endif // PHYSICS_3D_DISABLED
 
 	if (!is_root_shape()) {
-		parent_shape->_make_dirty();
+		parent_shape->_make_painted();
 	}
 #ifndef PHYSICS_3D_DISABLED
 	else if (!dirty) {
@@ -265,16 +266,26 @@ void CSGShape3D::_make_dirty(bool p_parent_removing) {
 	notify_property_list_changed();
 }
 
-void CSGShape3D::_make_painted() {
-	// TODO Fix this mess.
-	if (!is_root_shape()) {
+void CSGShape3D::_make_painted(bool p_paint) {
+	if (!brush) {
+		_make_dirty();
+	} else if (!is_root_shape()) {
+		painted = painted || p_paint;
+		if (!painted && !p_paint) {
+			_make_dirty;
+			return;
+		}
 		notify_property_list_changed();
-		// We force a rebuild of the parent shape only.
-		parent_shape->_make_dirty();
+		// We force a rebuild of the root shape only.
+		parent_shape->_make_painted();
 	} else {
 		// With this we can replace most calls to _make_dirty().
 		_make_dirty();
 	}
+}
+
+void _allow_editing() {
+	first_go = false;
 }
 
 enum ManifoldProperty {
@@ -492,23 +503,13 @@ struct ManifoldOperation {
 			manifold(m), operation(op) {}
 };
 
-CSGBrush *CSGShape3D::_get_brush() {
-	if (!dirty) {
-		return brush;
-	}
-	if (brush) {
-		memdelete(brush);
-	}
-	brush = nullptr;
-	CSGBrush *n = _build_brush();
-	HashMap<int32_t, Ref<Material>> mesh_materials;
-	manifold::Manifold root_manifold;
-	_pack_manifold(n, root_manifold, mesh_materials, this);
-	manifold::OpType current_op = ManifoldOperation::convert_csg_op(get_operation());
-	std::vector<manifold::Manifold> manifolds;
-	manifolds.push_back(root_manifold);
-	for (int i = 0; i < get_child_count(); i++) {
-		CSGShape3D *child = Object::cast_to<CSGShape3D>(get_child(i));
+static void _recursive_manifold(
+		std::vector<manifold::Manifold> &p_manifolds,
+		manifold::OpType &p_current_op,
+		HashMap<int32_t, Ref<Material>> &p_mesh_materials,
+		CSGShape3D *p_csg_shape) {
+	for (int i = 0; i < p_csg_shape->get_child_count(); i++) {
+		CSGShape3D *child = Object::cast_to<CSGShape3D>(p_csg_shape->get_child(i));
 		if (!child || !child->is_visible()) {
 			continue;
 		}
@@ -519,23 +520,71 @@ CSGBrush *CSGShape3D::_get_brush() {
 		CSGBrush transformed_brush;
 		transformed_brush.copy_from(*child_brush, child->get_transform());
 		manifold::Manifold child_manifold;
-		_pack_manifold(&transformed_brush, child_manifold, mesh_materials, child);
+		_pack_manifold(&transformed_brush, child_manifold, p_mesh_materials, child);
 		manifold::OpType child_operation = ManifoldOperation::convert_csg_op(child->get_operation());
-		if (child_operation != current_op) {
-			manifold::Manifold result = manifold::Manifold::BatchBoolean(manifolds, current_op);
-			manifolds.clear();
-			manifolds.push_back(result);
-			current_op = child_operation;
+		if (child_operation != p_current_op) {
+			manifold::Manifold result = manifold::Manifold::BatchBoolean(p_manifolds, p_current_op);
+			p_manifolds.clear();
+			p_manifolds.push_back(result);
+			p_current_op = child_operation;
 		}
-		manifolds.push_back(child_manifold);
+		p_manifolds.push_back(child_manifold);
+		if (child->get_child_count() > 0) {
+			_recursive_manifold(p_manifolds, p_current_op, p_mesh_materials, child);
+		}
 	}
-	if (!manifolds.empty()) {
-		manifold::Manifold manifold_result = manifold::Manifold::BatchBoolean(manifolds, current_op);
-		if (n) {
-			memdelete(n);
+}
+
+CSGBrush *CSGShape3D::_get_brush() {
+	if (!dirty) {
+		return brush;
+	}
+	if (brush) {
+		memdelete(brush);
+	}
+	brush = nullptr;
+	CSGBrush *n = _build_brush();
+	if (is_root_shape()) {
+		// CSG tree must iterate over all shapes, but we gain the ability to edit parent brushes and save them in their base form. This could reduce memory usage and just be faster because we work on simpler shapes, there's room for optimization.
+		HashMap<int32_t, Ref<Material>> mesh_materials;
+		manifold::Manifold root_manifold;
+		_pack_manifold(n, root_manifold, mesh_materials, this);
+		manifold::OpType current_op = ManifoldOperation::convert_csg_op(get_operation());
+		std::vector<manifold::Manifold> manifolds;
+		manifolds.push_back(root_manifold);
+		for (int i = 0; i < get_child_count(); i++) {
+			CSGShape3D *child = Object::cast_to<CSGShape3D>(get_child(i));
+			if (!child || !child->is_visible()) {
+				continue;
+			}
+			CSGBrush *child_brush = child->_get_brush();
+			if (!child_brush) {
+				continue;
+			}
+			CSGBrush transformed_brush;
+			transformed_brush.copy_from(*child_brush, child->get_transform());
+			manifold::Manifold child_manifold;
+			_pack_manifold(&transformed_brush, child_manifold, mesh_materials, child);
+			manifold::OpType child_operation = ManifoldOperation::convert_csg_op(child->get_operation());
+			if (child_operation != current_op) {
+				manifold::Manifold result = manifold::Manifold::BatchBoolean(manifolds, current_op);
+				manifolds.clear();
+				manifolds.push_back(result);
+				current_op = child_operation;
+			}
+			manifolds.push_back(child_manifold);
+			if (child->get_child_count() > 0) {
+				_recursive_manifold(manifolds, current_op, mesh_materials, child);
+			}
 		}
-		n = memnew(CSGBrush);
-		_unpack_manifold(manifold_result, mesh_materials, n);
+		if (!manifolds.empty()) {
+			manifold::Manifold manifold_result = manifold::Manifold::BatchBoolean(manifolds, current_op);
+			if (n) {
+				memdelete(n);
+			}
+			n = memnew(CSGBrush);
+			_unpack_manifold(manifold_result, mesh_materials, n);
+		}
 	}
 	AABB aabb;
 	if (n && !n->faces.is_empty()) {
@@ -548,6 +597,8 @@ CSGBrush *CSGShape3D::_get_brush() {
 	}
 	node_aabb = aabb;
 	brush = n;
+	first_go = false; // Allow editing after building brush.
+	painted = false;
 	dirty = false;
 	update_configuration_warnings();
 	return brush;
@@ -974,7 +1025,7 @@ void CSGShape3D::_notification(int p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_root_shape() && last_visible != is_visible()) {
 				// Update this node's parent only if its own visibility has changed, not the visibility of parent nodes
-				parent_shape->_make_dirty();
+				parent_shape->_make_painted();
 			}
 			last_visible = is_visible();
 		} break;
@@ -982,7 +1033,7 @@ void CSGShape3D::_notification(int p_what) {
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 			if (!is_root_shape()) {
 				// Update this node's parent only if its own transformation has changed, not the transformation of parent nodes
-				parent_shape->_make_dirty();
+				parent_shape->_make_painted();
 			}
 		} break;
 
@@ -1035,7 +1086,7 @@ CSGShape3D::Operation CSGShape3D::get_operation() const {
 
 void CSGShape3D::set_calculate_tangents(bool p_calculate_tangents) {
 	calculate_tangents = p_calculate_tangents;
-	_make_dirty();
+	_make_painted();
 }
 
 bool CSGShape3D::is_calculating_tangents() const {
@@ -1069,17 +1120,33 @@ void CSGShape3D::_validate_property(PropertyInfo &p_property) const {
 }
 
 Dictionary CSGShape3D::get_csg_brush() const {
+	Dictionary p_brush_data;
+	p_brush_data["painted"] = painted;
+
 	if (!brush) {
-		return Dictionary();
+		return p_brush_data;
+	}
+
+	if (is_root_shape) {
+		// Ideally, we want to rebuild the brush to undo any manifold operations.
+		// Changes on parents of nested shapes would be undone, it would be best if all shapes were siblings.
+		return p_brush_data;
+	}
+
+	if (!painted) {
+		// Only save painted brushes.
+		return p_brush_data;
 	}
 
 	CSGBrush *n = brush;
 
-	Dictionary p_brush_data;
+	if (n->faces.size() <= 0) {
+		return p_brush_data;
+	}
+
 	Vector<Vector3> vertices;
 	Vector<Vector2> uvs;
 	Vector<uint8_t> smooths;
-	Vector<uint8_t> inverts;
 	Vector<uint8_t> mat_id;
 	Array materials;
 
@@ -1090,7 +1157,6 @@ Dictionary CSGShape3D::get_csg_brush() const {
 		}
 
 		smooths.push_back(n->faces[i].smooth ? 1 : 0);
-		inverts.push_back(n->faces[i].invert ? 1 : 0);
 		mat_id.push_back(n->faces[i].material);
 	}
 
@@ -1098,7 +1164,8 @@ Dictionary CSGShape3D::get_csg_brush() const {
 	p_brush_data["uvs"] = uvs;
 	// Replace with smooth groups in the future.
 	p_brush_data["smooth"] = smooths;
-	p_brush_data["invert"] = inverts;
+	// We will not save combined shapes.
+	p_brush_data["inverted"] = n->faces[0].invert;
 	p_brush_data["material_id"] = mat_id;
 
 	for (int i = 0; i < n->materials.size(); i++) {
@@ -1118,8 +1185,22 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 	ERR_FAIL_COND(!p_brush_data.has("vertices"));
 	ERR_FAIL_COND(!p_brush_data.has("uvs"));
 	ERR_FAIL_COND(!p_brush_data.has("smooth"));
-	ERR_FAIL_COND(!p_brush_data.has("invert"));
+	ERR_FAIL_COND(!p_brush_data.has("inverted"));
 	ERR_FAIL_COND(!p_brush_data.has("materials"));
+
+	if (!p_brush_data.has("painted")) {
+		// Rebuild brush.
+		_allow_editing();
+		return;
+	}
+
+	if (!p_brush_data["painted"]) {
+		// Brush has not been modified or is root shape. Rebuild brush.
+		_allow_editing();
+		return;
+	}
+
+	painted = p_brush_data["painted"];
 
 	CSGBrush *n = memnew(CSGBrush);
 
@@ -1138,7 +1219,7 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 	invert.resize(face_count);
 
 	{
-		Vector<uint8_t> invrt = p_brush_data["invert"];
+		bool invrt = p_brush_data["inverted"];
 		Vector<uint8_t> smooth_i = p_brush_data["smooth"];
 		Array mats = p_brush_data["materials"];
 
@@ -1155,7 +1236,7 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 					materialsw[i] = t_mat;
 				}
 			}
-			invertw[i] = invrt[i] > 0;
+			invertw[i] = invrt;
 		}
 	}
 
@@ -1166,10 +1247,122 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 	}
 
 	brush = n;
+
+	callable_mp(this, &CSGShape3D::_allow_editing).call_deferred();
 }
 
 void CSGShape3D::rebuild_brush() {
-	_make_dirty();
+	if (first_go) {
+		_make_painted();
+	} else {
+		_make_dirty();
+	}
+}
+
+void CSGShape3D::set_uv_offsets(const Vector<int> &p_faces, const Vector2 &prev_offset, const Vector2 &p_offset) {
+	// Use the offset obtained from `get_uv_offsets` when selecting faces.
+	CSGBrush *n = _get_brush();
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			n->faces.write[p].uvs[j] = n->faces[p].uvs[j] + p_offset - prev_offset;
+		}
+	}
+	_make_painted(true);
+}
+
+Vector2 CSGShape3D::get_uv_offsets(int p_face) const {
+	if (!brush) {
+		return Vector2(0.0, 0.0);
+	}
+
+	CSGBrush *n = brush;
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	ERR_FAIL_INDEX(p_face, n->faces.size());
+	Vector2 smallest = n->faces[p_face].uvs[0];
+
+	for (int j = 1; j < 3; j++) {
+		Vector2 curr = n->faces[p_face].uvs[j];
+		if (curr.x < smallest.x) {
+			smallest.x = curr.x;
+		}
+		if (curr.y < smallest.y) {
+			smallest.y = curr.y;
+		}
+	}
+	return smallest;
+}
+
+void CSGShape3D::set_uv_scale(const Vector<int> &p_faces, const Vector2 &prev_scale, const Vector2 &p_scale) {
+	CSGBrush *n = _get_brush();
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	if (p_scale.x == 0.0 || p_scale.y == 0.0) {
+		ERR_PRINT("Scale can NEVER be ZERO!");
+		notify_property_list_changed();
+		return;
+	}
+
+	if (prev_scale == 0.0 || prev_scale == 0.0) {
+		// We fix this mess.
+		ERR_PRINT("Scale is ZERO, rebuilding shape.")
+		_make_dirty();
+		return;
+	}
+
+	Vector2 offset = get_uv_offsets(p_faces);
+	Vector2 n_scale = p_scale / prev_scale;
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			n->faces.write[p].uvs[j] = (n->faces[p].uvs[j] * n_scale) + offset;
+		}
+	}
+	_make_painted(true);
+}
+
+Vector2 CSGShape3D::get_uv_scale(int p_face) const {
+	if (!brush) {
+		return Vector2(1.0, 1.0);
+	}
+
+	CSGBrush *n = brush;
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	Vector2 offset = get_uv_offsets(p_face);
+	ERR_FAIL_INDEX(p_face, n->faces.size());
+	Vector2 largest = n->faces[p_face].uvs[0] - offset;
+	largest.x = Math::abs(largest.x);
+	largest.y = Math::abs(largest.y);
+
+	for (int j = 1; j < 3; j++) {
+		Vector2 curr = n->faces[p_face].uvs[j] - offset;
+		if (curr.x > largest.x) {
+			largest.x = curr.x;
+		}
+		if (curr.y > largest.y) {
+			largest.y = curr.y;
+		}
+	}
+	return largest;
 }
 
 void CSGShape3D::rotate_uv(const Vector<int> &p_faces, const float angle) {
@@ -1187,7 +1380,177 @@ void CSGShape3D::rotate_uv(const Vector<int> &p_faces, const float angle) {
 			n->faces.write[p].uvs[j] = p_rotation.xform(n->faces[p].uvs[j]);
 		}
 	}
-	_make_painted();
+	_make_painted(true);
+}
+
+void CSGShape3D::flip_x(const Vector<int> &p_faces) {
+	CSGBrush *n = _get_brush();
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	float mirror_x = -1.0;
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			Vector2 curr = n->faces[p].uvs[j];
+			curr.x *= mirror_x;
+			n->faces.write[p].uvs[j] = curr;
+		}
+	}
+	_make_painted(true);
+}
+
+void CSGShape3D::flip_y(const Vector<int> &p_faces) {
+	CSGBrush *n = _get_brush();
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	float mirror_y = -1.0;
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			Vector2 curr = n->faces[p].uvs[j];
+			curr.y *= mirror_y;
+			n->faces.write[p].uvs[j] = curr;
+		}
+	}
+	_make_painted(true);
+}
+
+bool CSGShape3D::resize_brush(const Vector3 &prev_size, const Vector3 &p_size) {
+	if (prev_size.x == 0.0 || prev_size.y == 0.0 || prev_size.z == 0.0) {
+		ERR_PRINT("size can NEVER be ZERO!");
+		_make_dirty();
+		return false;
+	}
+
+	if (p_size.x == 0.0 || p_size.y == 0.0 || p_size.z == 0.0) {
+		ERR_PRINT("size can NEVER be ZERO");
+		return false;
+	}
+
+	CSGBrush *n = brush;
+
+	if (n->faces.is_empty()) {
+		return false;
+	}
+
+	Vector3 n_size = p_size / prev_size;
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		for (int j = 0; j < 3; j++) {
+			Vector3 curr = n->faces[i].vertices[j];
+			curr *= n_size;
+			n->faces.write[i].vertices[j] = curr;
+		}
+	}
+	return true;
+}
+
+void set_csg_flat(bool p_mode) {
+	// This changes all faces so it can't be used with CSGCylinder3D.
+	CSGBrush *n = brush;
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	// TODO Smooth groups.
+	for (int i = 0; i < n->faces.size(); i++) {
+		n->faces.write[i].smooth = p_mode;
+	}
+}
+
+void CSGShape3D::set_face_material(const Vector<int> &p_faces, const Ref<Material> &p_material) {
+	CSGBrush *n = _get_brush();
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	int find_mat = -2;
+	if (p_material.is_valid()) {
+		for (int j = 0; j < n->materials.size(); j++) {
+			if (p_material == n->materials[j]) {
+				find_mat = j;
+				break;
+			}
+		}
+		if (find_mat == -2) {
+			// TODO Replace unused materials.
+			find_mat = materials.size();
+			materials.push_back(p_material);
+		}
+	} else {
+		find_mat = -1;
+	}
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		n->faces.write[p].material = find_mat;
+	}
+	// TODO make a different method for setting material for the whole shape.
+	_make_painted(true);
+}
+
+Ref<Material> CSGShape3D::get_face_material(int p_face) const {
+	// Using only one face as only one material will be returned.
+	CSGBrush *n = brush;
+
+	if (n->faces.is_empty()) {
+		return nullptr;
+	}
+
+	ERR_FAIL_INDEX(p_face, n->faces.size());
+	int mat = n->faces[p_face].material;
+	if (mat < 0) {
+		// mat can be -1
+		return nullptr;
+	}
+	return n->materials[mat];
+}
+
+Vector<Vector3> CSGShape3D::get_vertices() const {
+	// Use this for making a vertex editor.
+	CSGBox3D *n = brush;
+
+	Vector<Vector3> vertices;
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		for (int j = 0; j < 3; j++) {
+			Vector3 v = n->faces[i].vertices[j];
+			// TODO Optimize.
+			if (!vertices.find(v)) {
+				vertices.push_back(v);
+			}
+		}
+	}
+
+	return vertices;
+}
+
+void CSGShape3D::set_vertex_position(const Vector3 &curr_pos, const Vector3 &p_pos) {
+	CSGBrush *n = _get_brush();
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		for (int j = 0; j < 3; j++) {
+			if (n->faces[i].vertices[j].is_equal_approx(curr_pos)) {
+				n->faces.write[i].vertices[j] = p_pos;
+			}
+		}
+	}
+	_make_painted(true);
 }
 
 Array CSGShape3D::get_meshes() const {
@@ -1264,7 +1627,19 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_csg_brush", "csg_brush"), &CSGShape3D::set_csg_brush);
 	ClassDB::bind_method(D_METHOD("get_csg_brush"), &CSGShape3D::get_csg_brush);
 
+	ClassDB::bind_method(D_METHOD("rebuild_brush"), &CSGShape3D::rebuild_brush);
+	ClassDB::bind_method(D_METHOD("set_uv_offsets", "faces", "prev_offset", "p_offset"), &CSGShape3D::set_uv_offsets);
+	ClassDB::bind_method(D_METHOD("get_uv_offsets", "face"), &CSGShape3D::get_uv_offsets);
+	ClassDB::bind_method(D_METHOD("set_uv_scale", "faces", "prev_scale", "p_scale"), &CSGShape3D::set_uv_scale);
+	ClassDB::bind_method(D_METHOD("get_uv_scale", "face"), &CSGShape3D::get_uv_scale);
 	ClassDB::bind_method(D_METHOD("rotate_uv", "faces", "angle"), &CSGShape3D::rotate_uv);
+	ClassDB::bind_method(D_METHOD("flip_x", "faces"), &CSGShape3D::flip_x);
+	ClassDB::bind_method(D_METHOD("flip_y", "faces"), &CSGShape3D::flip_y);
+	ClassDB::bind_method(D_METHOD("resize_brush", "prev_size", "size"), &CSGShape3D::resize_brush);
+	ClassDB::bind_method(D_METHOD("set_face_material", "faces", "material"), &CSGShape3D::set_face_material);
+	ClassDB::bind_method(D_METHOD("get_face_material", "face"), &CSGShape3D::get_face_material);
+	ClassDB::bind_method(D_METHOD("get_vertices"), &CSGShape3D::get_vertices);
+	ClassDB::bind_method(D_METHOD("set_vertex_position", "from", "to"), &CSGShape3D::set_vertex_position);
 
 	ClassDB::bind_method(D_METHOD("get_meshes"), &CSGShape3D::get_meshes);
 
@@ -1353,7 +1728,7 @@ void CSGPrimitive3D::set_flip_faces(bool p_invert) {
 
 	flip_faces = p_invert;
 
-	_make_dirty();
+	_make_painted();
 }
 
 bool CSGPrimitive3D::get_flip_faces() {
@@ -1524,8 +1899,7 @@ void CSGMesh3D::set_material(const Ref<Material> &p_material) {
 		return;
 	}
 	material = p_material;
-	// TODO Make painted and add a method to change material of CSGBrush.
-	_make_dirty();
+	rebuild_brush();
 }
 
 Ref<Material> CSGMesh3D::get_material() const {
@@ -1721,9 +2095,10 @@ void CSGSphere3D::_bind_methods() {
 
 void CSGSphere3D::set_radius(const float p_radius) {
 	ERR_FAIL_COND(p_radius <= 0);
-	radius = p_radius;
-	// TODO Make painted and add a method to change scale.
-	_make_dirty();
+	if (resize_brush(Vector3(radius, radius, radius), Vector3(p_radius, p_radius, p_radius))) {
+		radius = p_radius;
+	}
+	_make_painted();
 	update_gizmos();
 }
 
@@ -1733,7 +2108,7 @@ float CSGSphere3D::get_radius() const {
 
 void CSGSphere3D::set_radial_segments(const int p_radial_segments) {
 	radial_segments = p_radial_segments > 4 ? p_radial_segments : 4;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -1743,7 +2118,7 @@ int CSGSphere3D::get_radial_segments() const {
 
 void CSGSphere3D::set_rings(const int p_rings) {
 	rings = p_rings > 1 ? p_rings : 1;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -1752,9 +2127,9 @@ int CSGSphere3D::get_rings() const {
 }
 
 void CSGSphere3D::set_smooth_faces(const bool p_smooth_faces) {
+	set_csg_flat(p_smooth_faces);
 	smooth_faces = p_smooth_faces;
-	// TODO Make painted and change smooth of all faces.
-	_make_dirty();
+	_make_painted();
 }
 
 bool CSGSphere3D::get_smooth_faces() const {
@@ -1763,8 +2138,7 @@ bool CSGSphere3D::get_smooth_faces() const {
 
 void CSGSphere3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	// TODO Make painted and add a method to change material of CSGBrush.
-	_make_dirty();
+	rebuild_brush();
 }
 
 Ref<Material> CSGSphere3D::get_material() const {
@@ -1893,9 +2267,10 @@ void CSGBox3D::_bind_methods() {
 }
 
 void CSGBox3D::set_size(const Vector3 &p_size) {
-	size = p_size;
-	// TODO Make painted and add a method to change scale of CSGBrush.
-	_make_dirty();
+	if (resize_brush(size, p_size)) {
+		size = p_size;
+	}
+	_make_painted();
 	update_gizmos();
 }
 
@@ -1908,17 +2283,17 @@ Vector3 CSGBox3D::get_size() const {
 bool CSGBox3D::_set(const StringName &p_name, const Variant &p_value) {
 	if (p_name == "width") {
 		size.x = p_value;
-		_make_dirty();
+		_make_painted();
 		update_gizmos();
 		return true;
 	} else if (p_name == "height") {
 		size.y = p_value;
-		_make_dirty();
+		_make_painted();
 		update_gizmos();
 		return true;
 	} else if (p_name == "depth") {
 		size.z = p_value;
-		_make_dirty();
+		_make_painted();
 		update_gizmos();
 		return true;
 	} else {
@@ -1929,8 +2304,7 @@ bool CSGBox3D::_set(const StringName &p_name, const Variant &p_value) {
 
 void CSGBox3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	// TODO Make painted and add a method to change material of CSGBrush.
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2103,9 +2477,10 @@ void CSGCylinder3D::_bind_methods() {
 }
 
 void CSGCylinder3D::set_radius(const float p_radius) {
-	radius = p_radius;
-	// TODO Make painted and add a method to change scale of CSGBrush.
-	_make_dirty();
+	if (resize_brush(Vector3(radius, 1.0, radius), Vector3(p_radius, 1.0, p_radius))) {
+		radius = p_radius;
+	}
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2114,9 +2489,10 @@ float CSGCylinder3D::get_radius() const {
 }
 
 void CSGCylinder3D::set_height(const float p_height) {
-	height = p_height;
-	// TODO Make painted and add a method to change scale of CSGBrush.
-	_make_dirty();
+	if (resize_brush(Vector3(1.0, height, 1.0), Vector3(1.0, p_height, 1.0))) {
+		height = p_height;
+	}
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2127,7 +2503,7 @@ float CSGCylinder3D::get_height() const {
 void CSGCylinder3D::set_sides(const int p_sides) {
 	ERR_FAIL_COND(p_sides < 3);
 	sides = p_sides;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2137,7 +2513,7 @@ int CSGCylinder3D::get_sides() const {
 
 void CSGCylinder3D::set_cone(const bool p_cone) {
 	cone = p_cone;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2147,7 +2523,7 @@ bool CSGCylinder3D::is_cone() const {
 
 void CSGCylinder3D::set_smooth_faces(const bool p_smooth_faces) {
 	smooth_faces = p_smooth_faces;
-	_make_dirty();
+	_make_painted();
 }
 
 bool CSGCylinder3D::get_smooth_faces() const {
@@ -2156,8 +2532,7 @@ bool CSGCylinder3D::get_smooth_faces() const {
 
 void CSGCylinder3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	// TODO Make painted and add a method to change material of CSGBrush.
-	_make_dirty();
+	rebuild_brush();
 }
 
 Ref<Material> CSGCylinder3D::get_material() const {
@@ -2332,7 +2707,7 @@ void CSGTorus3D::_bind_methods() {
 
 void CSGTorus3D::set_inner_radius(const float p_inner_radius) {
 	inner_radius = p_inner_radius;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2342,7 +2717,7 @@ float CSGTorus3D::get_inner_radius() const {
 
 void CSGTorus3D::set_outer_radius(const float p_outer_radius) {
 	outer_radius = p_outer_radius;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2353,7 +2728,7 @@ float CSGTorus3D::get_outer_radius() const {
 void CSGTorus3D::set_sides(const int p_sides) {
 	ERR_FAIL_COND(p_sides < 3);
 	sides = p_sides;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2364,7 +2739,7 @@ int CSGTorus3D::get_sides() const {
 void CSGTorus3D::set_ring_sides(const int p_ring_sides) {
 	ERR_FAIL_COND(p_ring_sides < 3);
 	ring_sides = p_ring_sides;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2373,8 +2748,9 @@ int CSGTorus3D::get_ring_sides() const {
 }
 
 void CSGTorus3D::set_smooth_faces(const bool p_smooth_faces) {
+	set_csg_flat(p_smooth_faces);
 	smooth_faces = p_smooth_faces;
-	_make_dirty();
+	_make_painted();
 }
 
 bool CSGTorus3D::get_smooth_faces() const {
@@ -2383,8 +2759,7 @@ bool CSGTorus3D::get_smooth_faces() const {
 
 void CSGTorus3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	// TODO Make painted and add a method to change material of CSGBrush.
-	_make_dirty();
+	rebuild_brush();
 }
 
 Ref<Material> CSGTorus3D::get_material() const {
@@ -2787,7 +3162,7 @@ void CSGPolygon3D::_validate_property(PropertyInfo &p_property) const {
 }
 
 void CSGPolygon3D::_path_changed() {
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2882,7 +3257,7 @@ void CSGPolygon3D::_bind_methods() {
 
 void CSGPolygon3D::set_polygon(const Vector<Vector2> &p_polygon) {
 	polygon = p_polygon;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2892,7 +3267,7 @@ Vector<Vector2> CSGPolygon3D::get_polygon() const {
 
 void CSGPolygon3D::set_mode(Mode p_mode) {
 	mode = p_mode;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 	notify_property_list_changed();
 }
@@ -2904,7 +3279,7 @@ CSGPolygon3D::Mode CSGPolygon3D::get_mode() const {
 void CSGPolygon3D::set_depth(const float p_depth) {
 	ERR_FAIL_COND(p_depth < 0.001);
 	depth = p_depth;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2914,7 +3289,7 @@ float CSGPolygon3D::get_depth() const {
 
 void CSGPolygon3D::set_path_continuous_u(bool p_enable) {
 	path_continuous_u = p_enable;
-	_make_dirty();
+	rebuild_brush();
 }
 
 bool CSGPolygon3D::is_path_continuous_u() const {
@@ -2923,7 +3298,7 @@ bool CSGPolygon3D::is_path_continuous_u() const {
 
 void CSGPolygon3D::set_path_u_distance(real_t p_path_u_distance) {
 	path_u_distance = p_path_u_distance;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2934,7 +3309,7 @@ real_t CSGPolygon3D::get_path_u_distance() const {
 void CSGPolygon3D::set_spin_degrees(const float p_spin_degrees) {
 	ERR_FAIL_COND(p_spin_degrees < 0.01 || p_spin_degrees > 360);
 	spin_degrees = p_spin_degrees;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2945,7 +3320,7 @@ float CSGPolygon3D::get_spin_degrees() const {
 void CSGPolygon3D::set_spin_sides(int p_spin_sides) {
 	ERR_FAIL_COND(p_spin_sides < 3);
 	spin_sides = p_spin_sides;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2955,7 +3330,7 @@ int CSGPolygon3D::get_spin_sides() const {
 
 void CSGPolygon3D::set_path_node(const NodePath &p_path) {
 	path_node = p_path;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2965,7 +3340,7 @@ NodePath CSGPolygon3D::get_path_node() const {
 
 void CSGPolygon3D::set_path_interval_type(PathIntervalType p_interval_type) {
 	path_interval_type = p_interval_type;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2975,7 +3350,7 @@ CSGPolygon3D::PathIntervalType CSGPolygon3D::get_path_interval_type() const {
 
 void CSGPolygon3D::set_path_interval(float p_interval) {
 	path_interval = p_interval;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2985,7 +3360,7 @@ float CSGPolygon3D::get_path_interval() const {
 
 void CSGPolygon3D::set_path_simplify_angle(float p_angle) {
 	path_simplify_angle = p_angle;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2995,7 +3370,7 @@ float CSGPolygon3D::get_path_simplify_angle() const {
 
 void CSGPolygon3D::set_path_rotation(PathRotation p_rotation) {
 	path_rotation = p_rotation;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -3005,7 +3380,7 @@ CSGPolygon3D::PathRotation CSGPolygon3D::get_path_rotation() const {
 
 void CSGPolygon3D::set_path_rotation_accurate(bool p_enabled) {
 	path_rotation_accurate = p_enabled;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -3015,7 +3390,7 @@ bool CSGPolygon3D::get_path_rotation_accurate() const {
 
 void CSGPolygon3D::set_path_local(bool p_enable) {
 	path_local = p_enable;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -3025,7 +3400,7 @@ bool CSGPolygon3D::is_path_local() const {
 
 void CSGPolygon3D::set_path_joined(bool p_enable) {
 	path_joined = p_enable;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -3035,7 +3410,7 @@ bool CSGPolygon3D::is_path_joined() const {
 
 void CSGPolygon3D::set_smooth_faces(const bool p_smooth_faces) {
 	smooth_faces = p_smooth_faces;
-	_make_dirty();
+	_make_painted();
 }
 
 bool CSGPolygon3D::get_smooth_faces() const {
@@ -3044,8 +3419,7 @@ bool CSGPolygon3D::get_smooth_faces() const {
 
 void CSGPolygon3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	// TODO Make painted and add a method to change material of CSGBrush.
-	_make_dirty();
+	rebuild_brush();
 }
 
 Ref<Material> CSGPolygon3D::get_material() const {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -507,7 +507,7 @@ struct ManifoldOperation {
 };
 
 CSGBrush *CSGShape3D::_get_brush() {
-	if (!dirty || !is_inside_tree()) {
+	if (!dirty) {
 		return brush;
 	}
 	if (brush) {
@@ -970,8 +970,6 @@ void CSGShape3D::_notification(int p_what) {
 					set_base(RID());
 					root_mesh.unref();
 					_make_painted();
-				} else {
-					rebuild_brush();
 				}
 			}
 			last_visible = is_visible();
@@ -1018,7 +1016,7 @@ void CSGShape3D::_notification(int p_what) {
 				set_collision_mask(collision_mask);
 				set_collision_priority(collision_priority);
 				debug_shape_old_transform = get_global_transform();
-				_make_painted();
+				rebuild_brush();
 			}
 		} break;
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -952,6 +952,11 @@ Vector<Vector3> CSGShape3D::get_brush_faces() {
 		}
 	}
 
+	if (get_operation() == OPERATION_SUBTRACTION) {
+		// Testing backface selection. If this doesn't work we need to think of a way to cull front faces so polygons can be selected on flipped or subtracting brushes.
+		faces.reverse();
+	}
+
 	return faces;
 }
 
@@ -1139,8 +1144,8 @@ Dictionary CSGShape3D::get_csg_brush() {
 	// Replace with smooth groups in the future.
 	p_brush_data["smooth"] = smooths;
 	// We will not save combined shapes.
-	p_brush_data["inverted"] = n->faces[0].invert;
 	p_brush_data["material_id"] = mat_id;
+	p_brush_data["ngons"] = n->ngons;
 
 	for (int i = 0; i < n->materials.size(); i++) {
 		materials.push_back(n->materials[i]);
@@ -1168,7 +1173,6 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 	ERR_FAIL_COND(!p_brush_data.has("vertices"));
 	ERR_FAIL_COND(!p_brush_data.has("uvs"));
 	ERR_FAIL_COND(!p_brush_data.has("smooth"));
-	ERR_FAIL_COND(!p_brush_data.has("inverted"));
 	ERR_FAIL_COND(!p_brush_data.has("materials"));
 
 	painted = p_brush_data["painted"];
@@ -1190,7 +1194,7 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 	invert.resize(face_count);
 
 	{
-		bool invrt = p_brush_data["inverted"];
+		bool invrt = get_flip_faces();
 		Vector<uint8_t> smooth_i = p_brush_data["smooth"];
 		Array mats = p_brush_data["materials"];
 
@@ -1214,6 +1218,12 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 	}
 
 	n->build_from_faces(faces, uvs, smooth, materials, invert);
+
+	if (p_brush_data.has("ngons")) {
+		n->add_ngons(p_brush_data["ngons"]);
+	} else {
+		WARN_PRINT("Resource doesn't have ngon data");
+	}
 
 	if (brush) {
 		memdelete(brush);
@@ -1409,41 +1419,8 @@ void CSGShape3D::flip_y(const Vector<int> &p_faces) {
 	_make_painted(true);
 }
 
-bool CSGShape3D::resize_brush(const Vector3 &prev_size, const Vector3 &p_size) {
-	CSGBrush *n = _get_brush();
-	if (n == nullptr) {
-		return true;
-	}
-
-	if (n->faces.is_empty()) {
-		return false;
-	}
-
-	if (prev_size.x == 0.0 || prev_size.y == 0.0 || prev_size.z == 0.0) {
-		ERR_PRINT("size can NEVER be ZERO!");
-		_make_dirty();
-		return false;
-	}
-
-	if (p_size.x == 0.0 || p_size.y == 0.0 || p_size.z == 0.0) {
-		ERR_PRINT("size can NEVER be ZERO");
-		return false;
-	}
-
-	Vector3 n_size = p_size / prev_size;
-
-	for (int i = 0; i < n->faces.size(); i++) {
-		for (int j = 0; j < 3; j++) {
-			Vector3 curr = n->faces[i].vertices[j];
-			curr *= n_size;
-			n->faces.write[i].vertices[j] = curr;
-		}
-	}
-	return true;
-}
-
-void CSGShape3D::set_csg_flat(bool p_mode) {
-	// This changes all faces so it can't be used with CSGCylinder3D.
+void CSGShape3D::calculate_cube_map(const Vector<int> &p_faces) {
+	// Simple cube map unwrapping. Calculates the normal of each face and aligns them with one of three axes.
 	CSGBrush *n = _get_brush();
 	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
@@ -1451,10 +1428,80 @@ void CSGShape3D::set_csg_flat(bool p_mode) {
 		return;
 	}
 
-	// TODO Smooth groups.
-	for (int i = 0; i < n->faces.size(); i++) {
-		n->faces.write[i].smooth = p_mode;
+	// 3D goes bot to top while 2D goes top to bottom.
+	Transform2D p_rotation = Transform2D(Math::deg_to_rad(180.0), Vector2(0.0, 0.0));
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+
+		Vector3 v1 = n->faces[p].vertices[0];
+		Vector3 v2 = n->faces[p].vertices[1];
+		Vector3 v3 = n->faces[p].vertices[2];
+
+		Plane ang(v1, v2, v3);
+		Vector3 nor = Vector3(Math::abs(ang.normal.x), Math::abs(ang.normal.y), Math::abs(ang.normal.z));
+
+		if (nor.x > nor.y && nor.x > nor.z) {
+			// Direction X, ZY.
+			float mir_x = ang.normal.x < 0.0 ? -1.0 : 1.0;
+			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(mir_x * v1.z, v1.y));
+			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(mir_x * v2.z, v2.y));
+			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(mir_x * v3.z, v3.y));
+		} else if (nor.y > nor.z) {
+			// Direction Y, XZ.
+			float mir_x = ang.normal.y < 0.0 ? -1.0 : 1.0;
+			n->faces.write[p].uvs[0] = Vector2(mir_x * v1.x, v1.z);
+			n->faces.write[p].uvs[1] = Vector2(mir_x * v2.x, v2.z);
+			n->faces.write[p].uvs[2] = Vector2(mir_x * v3.x, v3.z);
+		} else {
+			// Direction Z, XY.
+			float mir_x = ang.normal.z < 0.0 ? -1.0 : 1.0;
+			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(mir_x * v1.x, v1.y));
+			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(mir_x * v2.x, v2.y));
+			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(mir_x * v3.x, v3.y));
+		}
 	}
+	_make_painted(true);
+}
+
+void CSGShape3D::set_csg_face_smooth(const Vector<int> &p_faces, bool p_smooth) {
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			n->faces.write[p].smooth = p_smooth;
+		}
+	}
+	_make_painted(true);
+}
+
+bool CSGShape3D::is_csg_face_smooth(int p_face) {
+	if (!brush) {
+		return false;
+	}
+
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return false;
+	}
+
+	if (n->faces.is_empty()) {
+		return false;
+	}
+
+	if (p_face > n->faces.size() || p_face < 0) {
+		return false;
+	}
+
+	return n->faces[p_face].smooth;
 }
 
 void CSGShape3D::set_face_material(const Vector<int> &p_faces, const Ref<Material> &p_material) {
@@ -1519,8 +1566,6 @@ void CSGShape3D::set_face_material(const Vector<int> &p_faces, const Ref<Materia
 			n->materials.write[i] = nmats[i];
 		}
 	}
-
-	// TODO make a different method for setting material for the whole shape.
 	_make_painted(true);
 }
 
@@ -1547,6 +1592,74 @@ Ref<Material> CSGShape3D::get_face_material(int p_face) {
 	return n->materials[mat];
 }
 
+bool CSGShape3D::resize_brush(const Vector3 &prev_size, const Vector3 &p_size) {
+	if (!is_inside_tree()) {
+		return true;
+	}
+
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return true;
+	}
+
+	if (n->faces.is_empty()) {
+		return false;
+	}
+
+	if (prev_size.x == 0.0 || prev_size.y == 0.0 || prev_size.z == 0.0) {
+		ERR_PRINT("size can NEVER be ZERO!");
+		_make_dirty();
+		return false;
+	}
+
+	if (p_size.x == 0.0 || p_size.y == 0.0 || p_size.z == 0.0) {
+		ERR_PRINT("size can NEVER be ZERO");
+		return false;
+	}
+
+	Vector3 n_size = p_size / prev_size;
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		for (int j = 0; j < 3; j++) {
+			Vector3 curr = n->faces[i].vertices[j];
+			curr *= n_size;
+			n->faces.write[i].vertices[j] = curr;
+		}
+	}
+	return true;
+}
+
+void CSGShape3D::set_csg_invert() {
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	bool inv_val = get_flip_faces();
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		n->faces.write[i].invert = inv_val;
+	}
+	_make_painted();
+}
+
+void CSGShape3D::set_csg_flat(bool p_mode) {
+	// This changes all faces so it can't be used with CSGCylinder3D.
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	// TODO Smooth groups.
+	for (int i = 0; i < n->faces.size(); i++) {
+		n->faces.write[i].smooth = p_mode;
+	}
+}
+
 Vector<Vector3> CSGShape3D::get_vertices() {
 	// Use this for making a vertex editor.
 	CSGBrush *n = _get_brush();
@@ -1560,8 +1673,14 @@ Vector<Vector3> CSGShape3D::get_vertices() {
 	for (int i = 0; i < n->faces.size(); i++) {
 		for (int j = 0; j < 3; j++) {
 			Vector3 v = n->faces[i].vertices[j];
-			// TODO Optimize.
-			if (!vertices.find(v)) {
+			bool found_v = false;
+			for (int k = 0; k < vertices.size(); k++) {
+				if (vertices[k].is_equal_approx(v)) {
+					found_v = true;
+					break;
+				}
+			}
+			if (!found_v) {
 				vertices.push_back(v);
 			}
 		}
@@ -1583,52 +1702,6 @@ void CSGShape3D::set_vertex_position(const Vector3 &curr_pos, const Vector3 &p_p
 			if (n->faces[i].vertices[j].is_equal_approx(curr_pos)) {
 				n->faces.write[i].vertices[j] = p_pos;
 			}
-		}
-	}
-	_make_painted(true);
-}
-
-void CSGShape3D::calculate_cube_map(const Vector<int> &p_faces) {
-	// Simple cube map unwrapping. Calculates the normal of each face and aligns them with one of three axes.
-	CSGBrush *n = _get_brush();
-	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
-
-	if (n->faces.is_empty()) {
-		return;
-	}
-
-	// 3D goes bot to top while 2D goes top to bottom.
-	Transform2D p_rotation = Transform2D(Math::deg_to_rad(180.0), Vector2(0.0, 0.0));
-
-	for (int i = 0; i < p_faces.size(); i++) {
-		int p = p_faces[i];
-		ERR_FAIL_INDEX(p, n->faces.size());
-
-		Vector3 v1 = n->faces[p].vertices[0];
-		Vector3 v2 = n->faces[p].vertices[1];
-		Vector3 v3 = n->faces[p].vertices[2];
-
-		Plane ang(v1, v2, v3);
-		Vector3 nor = Vector3(Math::abs(ang.normal.x), Math::abs(ang.normal.y), Math::abs(ang.normal.z));
-
-		if (nor.x > nor.y && nor.x > nor.z) {
-			// Direction X, ZY.
-			float mir_x = ang.normal.x < 0.0 ? -1.0 : 1.0;
-			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(mir_x * v1.z, v1.y));
-			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(mir_x * v2.z, v2.y));
-			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(mir_x * v3.z, v3.y));
-		} else if (nor.y > nor.z) {
-			// Direction Y, XZ.
-			float mir_x = ang.normal.y < 0.0 ? -1.0 : 1.0;
-			n->faces.write[p].uvs[0] = Vector2(mir_x * v1.x, v1.z);
-			n->faces.write[p].uvs[1] = Vector2(mir_x * v2.x, v2.z);
-			n->faces.write[p].uvs[2] = Vector2(mir_x * v3.x, v3.z);
-		} else {
-			// Direction Z, XY.
-			float mir_x = ang.normal.z < 0.0 ? -1.0 : 1.0;
-			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(mir_x * v1.x, v1.y));
-			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(mir_x * v2.x, v2.y));
-			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(mir_x * v3.x, v3.y));
 		}
 	}
 	_make_painted(true);
@@ -1661,33 +1734,6 @@ Vector<Vector3> CSGShape3D::get_selected_faces(const Vector<int> &p_faces) {
 	return ret;
 }
 
-Vector<Vector3> CSGShape3D::get_csg_faces_anchor_points() {
-	// Returns the center of each face for displaying anchors. The original idea was for faces to be clicked on, but that might require too much work, and CSGs don't have that many faces anyway, fewer when ngons are implemented.
-	// This can be modified to display center of ngons in the future.
-	CSGBrush *n = _get_brush();
-
-	Vector<Vector3> ret;
-
-	if (n == nullptr) {
-		return ret;
-	}
-
-	if (n->faces.is_empty()) {
-		return ret;
-	}
-
-	for (int i = 0; i < n->faces.size(); i++) {
-		// TODO replace with ngons.
-		Vector3 aprox_pos = Vector3(0, 0, 0);
-		for (int j = 0; j < 3; j++) {
-			aprox_pos += n->faces[i].vertices[j];
-		}
-		aprox_pos /= 3;
-		ret.push_back(aprox_pos);
-	}
-	return ret;
-}
-
 int CSGShape3D::get_csg_num_faces() {
 	CSGBrush *n = _get_brush();
 
@@ -1698,49 +1744,6 @@ int CSGShape3D::get_csg_num_faces() {
 	return n->faces.size();
 }
 
-void CSGShape3D::set_csg_face_smooth(const Vector<int> &p_faces, bool p_smooth) {
-	CSGBrush *n = _get_brush();
-	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
-
-	if (n->faces.is_empty()) {
-		return;
-	}
-
-	for (int i = 0; i < p_faces.size(); i++) {
-		int p = p_faces[i];
-		ERR_FAIL_INDEX(p, n->faces.size());
-		for (int j = 0; j < 3; j++) {
-			n->faces.write[p].smooth = p_smooth;
-		}
-	}
-	_make_painted(true);
-}
-
-bool CSGShape3D::is_csg_face_smooth(int p_face) {
-	if (!brush) {
-		return false;
-	}
-
-	CSGBrush *n = _get_brush();
-	if (n == nullptr) {
-		return false;
-	}
-
-	if (n->faces.is_empty()) {
-		return false;
-	}
-
-	if (p_face > n->faces.size() || p_face < 0) {
-		return false;
-	}
-
-	return n->faces[p_face].smooth;
-}
-
-bool CSGShape3D::is_painted() const {
-	return painted;
-}
-
 Vector<int> CSGShape3D::get_all_csg_faces() {
 	Vector<int> all_faces;
 	all_faces.resize(get_csg_num_faces());
@@ -1748,6 +1751,115 @@ Vector<int> CSGShape3D::get_all_csg_faces() {
 		all_faces.write[i] = i;
 	}
 	return all_faces;
+}
+
+Vector<int> CSGShape3D::get_faces_from_ngon(int p_ngon) {
+	// Returns the faces (tris) forming the requested ngon. Use in combination with get_selected_faces().
+	CSGBrush *n = _get_brush();
+	Vector<int> ret;
+
+	if (n == nullptr) {
+		return ret;
+	}
+
+	if (n->faces.is_empty()) {
+		return ret;
+	}
+
+	if (n->ngons.is_empty() || n->num_ngons < 1) {
+		ERR_PRINT("CSGBrush has no ngons!");
+		return ret;
+	}
+
+	ret = n->get_ngon_faces(p_ngon);
+	return ret;
+}
+
+TypedArray<Vector<Vector3>> CSGShape3D::get_csg_ngon_colliders() {
+	// Returns an array of Vector<Vector3> to use to create a TriangleMesh for each collider of ngon to be used in gizmos.
+	// This could probably work better if it returns TriangleMesh, as it will be used for collision.
+	TypedArray<Vector<Vector3>> ret;
+	CSGBrush *n = _get_brush();
+
+	if (n == nullptr) {
+		return ret;
+	}
+
+	if (n->ngons.is_empty() || n->num_ngons < 1) {
+		ERR_PRINT("CSGBrush has no ngons");
+		return ret;
+	}
+
+	if (n->faces.is_empty()) {
+		ERR_PRINT("CSGBrush has no faces!");
+		return ret;
+	}
+
+	if (n->num_ngons < 0) {
+		ERR_PRINT("num_ngons is less than 0");
+		return ret;
+	}
+
+	ret.resize(n->num_ngons);
+	for (int i = 0; i < n->num_ngons; i++) {
+		Vector<int> curr_ngon = n->get_ngon_faces(i);
+		if (curr_ngon != nullptr) {
+			Vector<Vector3> curr_faces;
+			for (int j = 0; j < curr_ngon.size(); j++) {
+				curr_faces.push_back(n->faces[j].vertices[0])
+				curr_faces.push_back(n->faces[j].vertices[1])
+				curr_faces.push_back(n->faces[j].vertices[2])
+			}
+			ret[i] = curr_faces;
+		}
+	}
+
+	if (get_flip_faces() || get_operation() == OPERATION_SUBTRACTION) {
+		ret.reverse();
+	}
+
+	return ret;
+}
+
+Vector<Vector3> CSGShape3D::get_all_ngon_lines() {
+	// Nicer looking lines.
+	Vector<Vector3> ret;
+	CSGBrush *n = _get_brush();
+
+	if (n->ngons.is_empty() || n->num_ngons < 1 || n->num_ngons < 0) {
+		// Don't throw error, instead default to older behaviour.
+		return ret;
+	}
+
+	// TODO Move to gizmos.
+	TypedArray<Vector<Vector3>> local_csg_faces = get_csg_ngon_colliders();
+
+	// TODO Optimize.
+	for (int i = 0; i < local_csg_faces.size(); i++) {
+		Vector<Vector3> local_edges;
+		for (int j = 0; j < local_csg_faces[i].size() / 3; j++) {
+			for (int k = 0; k < 3; k++) {
+				int k_n = (k + 1) % 3;
+				local_edges.push_back(local_csg_faces[i * 3 + k]);
+				local_edges.push_back(local_csg_faces[i * 3 + k_n]);
+			}
+		}
+		for (int j = 0; j < local_edges.size() / 2; j++) {
+			for (int k = j; k < local_edges.size() / 2; k++) {
+				// TODO Simplify.
+				bool comp_edges = (local_edges[j * 2] == local_edges[k * 2] && local_edges[j * 2 + 1] == local_edges[k * 2 + 1]) && (local_edges[j * 2] == local_edges[k * 2 + 1] && local_edges[j * 2 + 1] == local_edges[k * 2]);
+				if (!comp_edges) {
+					ret.push_back(local_edges[j * 2]);
+					ret.push_back(local_edges[j * 2 + 1]);
+				}
+			}
+		}
+	}
+	return ret;
+}
+
+bool CSGShape3D::is_painted() const {
+	return painted;
 }
 
 Array CSGShape3D::get_meshes() const {
@@ -1832,17 +1944,19 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("rotate_uv", "faces", "angle"), &CSGShape3D::rotate_uv);
 	ClassDB::bind_method(D_METHOD("flip_x", "faces"), &CSGShape3D::flip_x);
 	ClassDB::bind_method(D_METHOD("flip_y", "faces"), &CSGShape3D::flip_y);
-	ClassDB::bind_method(D_METHOD("resize_brush", "prev_size", "size"), &CSGShape3D::resize_brush);
-	ClassDB::bind_method(D_METHOD("set_face_material", "faces", "material"), &CSGShape3D::set_face_material);
-	ClassDB::bind_method(D_METHOD("get_face_material", "face"), &CSGShape3D::get_face_material);
-	ClassDB::bind_method(D_METHOD("get_vertices"), &CSGShape3D::get_vertices);
-	ClassDB::bind_method(D_METHOD("set_vertex_position", "from", "to"), &CSGShape3D::set_vertex_position);
 	ClassDB::bind_method(D_METHOD("calculate_cube_map", "faces"), &CSGShape3D::calculate_cube_map);
-	ClassDB::bind_method(D_METHOD("get_selected_faces", "faces"), &CSGShape3D::get_selected_faces);
-	ClassDB::bind_method(D_METHOD("get_csg_faces_anchor_points"), &CSGShape3D::get_csg_faces_anchor_points);
-	ClassDB::bind_method(D_METHOD("get_csg_num_faces"), &CSGShape3D::get_csg_num_faces);
 	ClassDB::bind_method(D_METHOD("set_csg_face_smooth", "faces", "smooth"), &CSGShape3D::set_csg_face_smooth);
 	ClassDB::bind_method(D_METHOD("is_csg_face_smooth", "face"), &CSGShape3D::is_csg_face_smooth);
+	ClassDB::bind_method(D_METHOD("set_face_material", "faces", "material"), &CSGShape3D::set_face_material);
+	ClassDB::bind_method(D_METHOD("get_face_material", "face"), &CSGShape3D::get_face_material);
+	ClassDB::bind_method(D_METHOD("resize_brush", "prev_size", "size"), &CSGShape3D::resize_brush);
+	ClassDB::bind_method(D_METHOD("get_vertices"), &CSGShape3D::get_vertices);
+	ClassDB::bind_method(D_METHOD("set_vertex_position", "from", "to"), &CSGShape3D::set_vertex_position);
+	ClassDB::bind_method(D_METHOD("get_selected_faces", "faces"), &CSGShape3D::get_selected_faces);
+	ClassDB::bind_method(D_METHOD("get_csg_num_faces"), &CSGShape3D::get_csg_num_faces);
+	ClassDB::bind_method(D_METHOD("get_all_csg_faces"), &CSGShape3D::get_all_csg_faces);
+	ClassDB::bind_method(D_METHOD("get_faces_from_ngon", "p_ngon"), &CSGShape3D::get_faces_from_ngon);
+	ClassDB::bind_method(D_METHOD("get_csg_ngon_colliders"), &CSGShape3D::get_csg_ngon_colliders);
 
 	ClassDB::bind_method(D_METHOD("get_meshes"), &CSGShape3D::get_meshes);
 
@@ -1914,6 +2028,15 @@ CSGBrush *CSGPrimitive3D::_create_brush_from_arrays(const Vector<Vector3> &p_ver
 	}
 	new_brush->build_from_faces(p_vertices, p_uv, p_smooth, p_materials, invert);
 
+	// Meshes are imported as triangles so there's no way to use quads from here.
+	Vector<int> ngons;
+	ngons.resize(new_brush->faces.size());
+	for (int i = 0; i < ngons.size(); i++) {
+		ngons.write[i] = i;
+	}
+
+	new_brush->add_ngons(ngons);
+
 	return new_brush;
 }
 
@@ -1930,6 +2053,10 @@ void CSGPrimitive3D::set_flip_faces(bool p_invert) {
 	}
 
 	flip_faces = p_invert;
+
+	if ((is_painted() && p_invert) || (!is_root_shape() && is_inside_tree())) {
+		set_csg_invert();
+	}
 
 	_make_painted();
 }
@@ -2161,6 +2288,9 @@ CSGBrush *CSGSphere3D::_build_brush() {
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
+	Vector<int> ngons;
+	ngons.resize(face_count);
+
 	faces.resize(face_count * 3);
 	uvs.resize(face_count * 3);
 
@@ -2174,6 +2304,9 @@ CSGBrush *CSGSphere3D::_build_brush() {
 		bool *smoothw = smooth.ptrw();
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
+		int *ngonw = ngons.ptrw();
+
+		int ngon_counter = 0;
 
 		// We want to follow an order that's convenient for UVs.
 		// For latitude step we start at the top and move down like in an image.
@@ -2244,6 +2377,8 @@ CSGBrush *CSGSphere3D::_build_brush() {
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
 
+					ngonw[face] = ngon_counter;
+
 					face++;
 				}
 
@@ -2261,8 +2396,11 @@ CSGBrush *CSGSphere3D::_build_brush() {
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
 
+					ngonw[face] = ngon_counter;
+
 					face++;
 				}
+				ngon_counter++;
 			}
 		}
 
@@ -2272,6 +2410,7 @@ CSGBrush *CSGSphere3D::_build_brush() {
 	}
 
 	new_brush->build_from_faces(faces, uvs, smooth, materials, invert);
+	new_brush->add_ngons(ngons);
 
 	return new_brush;
 }
@@ -2380,6 +2519,9 @@ CSGBrush *CSGBox3D::_build_brush() {
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
+	Vector<int> ngons;
+	ngons.resize(face_count);
+
 	faces.resize(face_count * 3);
 	uvs.resize(face_count * 3);
 
@@ -2393,6 +2535,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 		bool *smoothw = smooth.ptrw();
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
+		int *ngonw = ngons.ptrw();
 
 		int face = 0;
 
@@ -2450,6 +2593,8 @@ CSGBrush *CSGBox3D::_build_brush() {
 				invertw[face] = invert_val;
 				materialsw[face] = base_material;
 
+				ngonw[face] = face / 2;
+
 				face++;
 			}
 		}
@@ -2460,6 +2605,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 	}
 
 	new_brush->build_from_faces(faces, uvs, smooth, materials, invert);
+	new_brush->add_ngons(ngons);
 
 	return new_brush;
 }
@@ -2543,6 +2689,9 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
+	Vector<int> ngons;
+	ngons.resize(face_count);
+
 	faces.resize(face_count * 3);
 	uvs.resize(face_count * 3);
 
@@ -2557,11 +2706,14 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
 
+		int *ngonw = ngons.ptrw();
+
 		int face = 0;
 
 		Vector3 vertex_mul(radius, height * 0.5, radius);
 
 		{
+			int ngon_counter = cone ? 1 : 2;
 			for (int i = 0; i < sides; i++) {
 				float inc = float(i) / sides;
 				float inc_n = float((i + 1)) / sides;
@@ -2602,6 +2754,8 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 				invertw[face] = invert_val;
 				materialsw[face] = base_material;
 
+				ngonw[face] = ngon_counter;
+
 				face++;
 
 				if (!cone) {
@@ -2617,8 +2771,13 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 					smoothw[face] = smooth_faces;
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
+
+					ngonw[face] = ngon_counter;
+
 					face++;
 				}
+
+				ngon_counter++;
 
 				//bottom face 1
 				facesw[face * 3 + 0] = face_points[1] * vertex_mul;
@@ -2632,6 +2791,7 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 				smoothw[face] = false;
 				invertw[face] = invert_val;
 				materialsw[face] = base_material;
+				ngonw[face] = 0;
 				face++;
 
 				if (!cone) {
@@ -2647,6 +2807,7 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 					smoothw[face] = false;
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
+					ngonw[face] = 1;
 					face++;
 				}
 			}
@@ -2658,6 +2819,7 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 	}
 
 	new_brush->build_from_faces(faces, uvs, smooth, materials, invert);
+	new_brush->add_ngons(ngons);
 
 	return new_brush;
 }
@@ -2798,6 +2960,9 @@ CSGBrush *CSGTorus3D::_build_brush() {
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
+	Vector<int> ngons;
+	ngons.resize(face_count);
+
 	faces.resize(face_count * 3);
 	uvs.resize(face_count * 3);
 
@@ -2812,9 +2977,12 @@ CSGBrush *CSGTorus3D::_build_brush() {
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
 
+		int *ngonw = ngons.ptrw();
+
 		int face = 0;
 
 		{
+			int ngon_counter = 0;
 			for (int i = 0; i < sides; i++) {
 				float inci = float(i) / sides;
 				float inci_n = float((i + 1)) / sides;
@@ -2868,6 +3036,8 @@ CSGBrush *CSGTorus3D::_build_brush() {
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
 
+					ngonw[face] = ngon_counter;
+
 					face++;
 
 					//face 2
@@ -2882,7 +3052,11 @@ CSGBrush *CSGTorus3D::_build_brush() {
 					smoothw[face] = smooth_faces;
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
+
+					ngonw[face] = ngon_counter;
+
 					face++;
+					ngon_counter++;
 				}
 			}
 		}
@@ -2893,6 +3067,7 @@ CSGBrush *CSGTorus3D::_build_brush() {
 	}
 
 	new_brush->build_from_faces(faces, uvs, smooth, materials, invert);
+	new_brush->add_ngons(ngons);
 
 	return new_brush;
 }
@@ -3089,6 +3264,9 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
+	Vector<int> ngons;
+	ngons.resize(face_count);
+
 	faces.resize(face_count * 3);
 	uvs.resize(face_count * 3);
 	smooth.resize(face_count);
@@ -3102,6 +3280,10 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 		bool *smoothw = smooth.ptrw();
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
+
+		int *ngonw = ngons.ptrw();
+
+		int ngon_counter = 0;
 
 		int face = 0;
 		Transform3D base_xform;
@@ -3184,8 +3366,10 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 				smoothw[face] = false;
 				materialsw[face] = base_material;
 				invertw[face] = flip_faces;
+				ngonw[face] = ngon_counter;
 				face++;
 			}
+			ngon_counter++;
 		}
 
 		real_t angle_simplify_dot = Math::cos(Math::deg_to_rad(path_simplify_angle));
@@ -3300,6 +3484,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 				smoothw[face] = smooth_faces;
 				invertw[face] = flip_faces;
 				materialsw[face] = base_material;
+				ngonw[face] = ngon_counter;
 
 				face++;
 
@@ -3315,6 +3500,8 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 				smoothw[face] = smooth_faces;
 				invertw[face] = flip_faces;
 				materialsw[face] = base_material;
+				ngonw[face] = ngon_counter;
+				ngon_counter++;
 
 				face++;
 			}
@@ -3339,6 +3526,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 				smoothw[face] = false;
 				materialsw[face] = base_material;
 				invertw[face] = flip_faces;
+				ngonw[face] = ngon_counter;
 				face++;
 			}
 		}
@@ -3353,9 +3541,11 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 		smooth.resize(face_count);
 		materials.resize(face_count);
 		invert.resize(face_count);
+		ngons.resize(face_count); // What does this do?
 	}
 
 	new_brush->build_from_faces(faces, uvs, smooth, materials, invert);
+	new_brush->add_ngons(ngons);
 
 	return new_brush;
 }

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -976,7 +976,7 @@ void CSGShape3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
-			// Build the brush build only once all children are inside the tree.
+			// Build the brush only once all children are inside the tree.
 			if (is_root_shape()) {
 				rebuild_brush();
 			}
@@ -3191,7 +3191,9 @@ void CSGTorus3D::_bind_methods() {
 
 void CSGTorus3D::set_inner_radius(const float p_inner_radius) {
 	inner_radius = p_inner_radius;
-	resize_brush_rework();
+	if (is_painted()) {
+		resize_brush_rework();
+	}
 	_make_painted();
 	update_gizmos();
 }
@@ -3202,7 +3204,9 @@ float CSGTorus3D::get_inner_radius() const {
 
 void CSGTorus3D::set_outer_radius(const float p_outer_radius) {
 	outer_radius = p_outer_radius;
-	resize_brush_rework();
+	if (is_painted()) {
+		resize_brush_rework();
+	}
 	_make_painted();
 	update_gizmos();
 }
@@ -3792,7 +3796,9 @@ CSGPolygon3D::Mode CSGPolygon3D::get_mode() const {
 void CSGPolygon3D::set_depth(const float p_depth) {
 	ERR_FAIL_COND(p_depth < 0.001);
 	depth = p_depth;
-	resize_brush_rework();
+	if (is_painted()) {
+		resize_brush_rework();
+	}
 	_make_painted();
 	update_gizmos();
 }
@@ -3924,7 +3930,9 @@ bool CSGPolygon3D::get_path_rotation_accurate() const {
 
 void CSGPolygon3D::set_path_local(bool p_enable) {
 	path_local = p_enable;
-	resize_brush_rework();
+	if (is_painted()) {
+		resize_brush_rework();
+	}
 	_make_painted();
 	update_gizmos();
 }

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1806,9 +1806,9 @@ TypedArray<Vector<Vector3>> CSGShape3D::get_csg_ngon_colliders() {
 		if (curr_ngon != nullptr) {
 			Vector<Vector3> curr_faces;
 			for (int j = 0; j < curr_ngon.size(); j++) {
-				curr_faces.push_back(n->faces[j].vertices[0])
-				curr_faces.push_back(n->faces[j].vertices[1])
-				curr_faces.push_back(n->faces[j].vertices[2])
+				curr_faces.push_back(n->faces[j].vertices[0]);
+				curr_faces.push_back(n->faces[j].vertices[1]);
+				curr_faces.push_back(n->faces[j].vertices[2]);
 			}
 			ret[i] = curr_faces;
 		}
@@ -1827,7 +1827,7 @@ Vector<Vector3> CSGShape3D::get_all_ngon_lines() {
 	CSGBrush *n = _get_brush();
 
 	if (n->ngons.is_empty() || n->num_ngons < 1 || n->num_ngons < 0) {
-		// Don't throw error, instead default to older behaviour.
+		// Don't throw error, instead default to older behavior.
 		return ret;
 	}
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2164,7 +2164,7 @@ CSGBrush *CSGMesh3D::_build_brush() {
 					if (!prev_tri_normal.is_equal_approx(normal[0])) {
 						ngon_counter++;
 					}
-					prev_tri_normal = normal;
+					prev_tri_normal = normal[0];
 				} else {
 					prev_tri_normal = Vector3(0, 0, 0);
 					ngon_counter++;
@@ -2221,7 +2221,7 @@ CSGBrush *CSGMesh3D::_build_brush() {
 					if (!prev_tri_normal.is_equal_approx(normal[0])) {
 						ngon_counter++;
 					}
-					prev_tri_normal = normal;
+					prev_tri_normal = normal[0];
 				} else {
 					prev_tri_normal = Vector3(0, 0, 0);
 					ngon_counter++;

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1805,9 +1805,9 @@ TypedArray<Vector<Vector3>> CSGShape3D::get_csg_ngon_colliders() {
 		if (!curr_ngon.is_empty()) {
 			Vector<Vector3> curr_faces;
 			for (int j = 0; j < curr_ngon.size(); j++) {
-				curr_faces.push_back(n->faces[j].vertices[0]);
-				curr_faces.push_back(n->faces[j].vertices[1]);
-				curr_faces.push_back(n->faces[j].vertices[2]);
+				curr_faces.push_back(n->faces[curr_ngon[j]].vertices[0]);
+				curr_faces.push_back(n->faces[curr_ngon[j]].vertices[1]);
+				curr_faces.push_back(n->faces[curr_ngon[j]].vertices[2]);
 			}
 			ret.push_back(curr_faces);
 		}

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -266,15 +266,15 @@ void CSGShape3D::_make_dirty(bool p_parent_removing) {
 	notify_property_list_changed();
 }
 
-void CSGShape3D::_make_painted(bool p_paint) {
+void CSGShape3D::_make_painted(bool p_paint = false) {
 	if (!brush) {
 		_make_dirty();
 	} else if (!is_root_shape()) {
-		painted = painted || p_paint;
 		if (!painted && !p_paint) {
 			_make_dirty();
 			return;
 		}
+		painted = painted || p_paint;
 		notify_property_list_changed();
 		// We force a rebuild of the root shape only.
 		parent_shape->_make_painted();
@@ -282,10 +282,6 @@ void CSGShape3D::_make_painted(bool p_paint) {
 		// With this we can replace most calls to _make_dirty().
 		_make_dirty();
 	}
-}
-
-void CSGShape3D::_allow_editing() {
-	first_go = false;
 }
 
 enum ManifoldProperty {
@@ -513,18 +509,17 @@ CSGBrush *CSGShape3D::_get_brush() {
 	brush = nullptr;
 	CSGBrush *n = _build_brush();
 	if (is_root_shape()) {
-		// CSG tree must iterate over all shapes, but we gain the ability to edit parent brushes and save them in their base form. This could reduce memory usage and just be faster because we work on simpler shapes, there's room for optimization.
+		// CSG tree must iterate over all shapes, but we gain the ability to edit parent brushes and save them in their base form.
 		HashMap<int32_t, Ref<Material>> mesh_materials;
 		manifold::Manifold root_manifold;
 		_pack_manifold(n, root_manifold, mesh_materials, this);
 		manifold::OpType current_op = ManifoldOperation::convert_csg_op(get_operation());
 		std::vector<manifold::Manifold> manifolds;
 		manifolds.push_back(root_manifold);
-		for (int i = 0; i < get_child_count(); i++) {
-			CSGShape3D *child = Object::cast_to<CSGShape3D>(get_child(i));
-			if (!child || !child->is_visible()) {
-				continue;
-			}
+		Vector<CSGShape3D *> children;
+		get_csg_children_recursive(children);
+		for (int i = 0; i < children.size(); i++) {
+			CSGShape3D *child = children[i];
 			CSGBrush *child_brush = child->_get_brush();
 			if (!child_brush) {
 				continue;
@@ -541,7 +536,6 @@ CSGBrush *CSGShape3D::_get_brush() {
 				current_op = child_operation;
 			}
 			manifolds.push_back(child_manifold);
-			// TODO Get children recursively. This is only going to work with siblings for now.
 		}
 		if (!manifolds.empty()) {
 			manifold::Manifold manifold_result = manifold::Manifold::BatchBoolean(manifolds, current_op);
@@ -563,8 +557,6 @@ CSGBrush *CSGShape3D::_get_brush() {
 	}
 	node_aabb = aabb;
 	brush = n;
-	first_go = false; // Allow editing after building brush.
-	painted = false;
 	dirty = false;
 	update_configuration_warnings();
 	return brush;
@@ -1085,6 +1077,17 @@ void CSGShape3D::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
+void get_csg_children_recursive(Vector<CSGShape3D *> &p_nodes) {
+	for (int i = 0; i < get_child_count(); i++) {
+		CSGShape3D *child = Object::cast_to<CSGShape3D>(get_child(i));
+		if (!child || !child->is_visible()) {
+			continue;
+		}
+		p_nodes.push_back(child);
+		child->get_csg_children_recursive(p_nodes);
+	}
+}
+
 Dictionary CSGShape3D::get_csg_brush() {
 	Dictionary p_brush_data;
 	p_brush_data["painted"] = painted;
@@ -1138,10 +1141,7 @@ Dictionary CSGShape3D::get_csg_brush() {
 	p_brush_data["material_id"] = mat_id;
 
 	for (int i = 0; i < n->materials.size(); i++) {
-		// TODO Make sure something is written in the space if the material is not valid.
-		if (n->materials[i].is_valid()) {
-			materials.push_back(n->materials[i]);
-		}
+		materials.push_back(n->materials[i]);
 	}
 
 	p_brush_data["materials"] = materials;
@@ -1150,24 +1150,22 @@ Dictionary CSGShape3D::get_csg_brush() {
 }
 
 void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
+	if (!p_brush_data.has("painted")) {
+		// Rebuild brush.
+		return;
+	}
+
+	if (!p_brush_data["painted"]) {
+		// Brush has not been modified or is root shape. Rebuild brush.
+		return;
+	}
+
 	ERR_FAIL_COND(!p_brush_data.has("material_id"));
 	ERR_FAIL_COND(!p_brush_data.has("vertices"));
 	ERR_FAIL_COND(!p_brush_data.has("uvs"));
 	ERR_FAIL_COND(!p_brush_data.has("smooth"));
 	ERR_FAIL_COND(!p_brush_data.has("inverted"));
 	ERR_FAIL_COND(!p_brush_data.has("materials"));
-
-	if (!p_brush_data.has("painted")) {
-		// Rebuild brush.
-		_allow_editing();
-		return;
-	}
-
-	if (!p_brush_data["painted"]) {
-		// Brush has not been modified or is root shape. Rebuild brush.
-		_allow_editing();
-		return;
-	}
 
 	painted = p_brush_data["painted"];
 
@@ -1203,6 +1201,8 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 				Ref<Material> t_mat = mats[i_mat];
 				if (t_mat.is_valid()) {
 					materialsw[i] = t_mat;
+				} else {
+					materialsw[i] = nullptr;
 				}
 			}
 			invertw[i] = invrt;
@@ -1217,15 +1217,11 @@ void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
 
 	brush = n;
 
-	callable_mp(this, &CSGShape3D::_allow_editing).call_deferred();
+	dirty = false;
 }
 
 void CSGShape3D::rebuild_brush() {
-	if (first_go) {
-		_make_painted();
-	} else {
-		_make_dirty();
-	}
+	_make_dirty();
 }
 
 void CSGShape3D::set_uv_offsets(const Vector<int> &p_faces, const Vector2 &prev_offset, const Vector2 &p_offset) {
@@ -1474,7 +1470,7 @@ void CSGShape3D::set_face_material(const Vector<int> &p_faces, const Ref<Materia
 			}
 		}
 		if (find_mat == -2) {
-			// TODO Replace unused materials.
+			// TODO Remove unused materials.
 			find_mat = n->materials.size();
 			n->materials.push_back(p_material);
 		}
@@ -1553,6 +1549,70 @@ void CSGShape3D::set_vertex_position(const Vector3 &curr_pos, const Vector3 &p_p
 		}
 	}
 	_make_painted(true);
+}
+
+void CSGShape3D::calculate_cube_map(const Vector<int> &p_faces) {
+	// Simple cube map unwrapping. Calculates the normal of each face and aligns them with one of three axes.
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+
+		Vector3 v1 = n->faces[p].vertices[0];
+		Vector3 v2 = n->faces[p].vertices[1];
+		Vector3 v3 = n->faces[p].vertices[2];
+
+		Plane ang(v1, v2, v3);
+		Vector3 nor = Vector3(Math::abs(ang.normal.x), Math::abs(ang.normal.y), Math::abs(ang.normal.z));
+
+		if (nor.x > nor.y && nor.x > nor.z) {
+			// Direction X, ZY.
+			n->faces.write[p].uvs[0] = Vector2(v1.z, v1.y);
+			n->faces.write[p].uvs[1] = Vector2(v2.z, v2.y);
+			n->faces.write[p].uvs[2] = Vector2(v3.z, v3.y);
+		} else if (nor.y > nor.z) {
+			// Direction Y, XZ.
+			n->faces.write[p].uvs[0] = Vector2(v1.x, v1.z);
+			n->faces.write[p].uvs[1] = Vector2(v2.x, v2.z);
+			n->faces.write[p].uvs[2] = Vector2(v3.x, v3.z);
+		} else {
+			// Direction Z, XY.
+			n->faces.write[p].uvs[0] = Vector2(v1.x, v1.y);
+			n->faces.write[p].uvs[1] = Vector2(v2.x, v2.y);
+			n->faces.write[p].uvs[2] = Vector2(v3.x, v3.y);
+		}
+	}
+	_make_painted(true);
+}
+
+Vector<Vector3> CSGShape3D::get_selected_faces(const Vector<int> &p_faces) {
+	// Use this to obtain a vector of selected faces to display as a mesh in editor.
+	CSGBrush *n = _get_brush();
+
+	Vector<Vector3> ret;
+
+	if (n == nullptr) {
+		return ret;
+	}
+
+	if (n->faces.is_empty()) {
+		return ret;
+	}
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			ret.push_back(n->faces[p].vertices[j]);
+		}
+	}
+	return ret;
 }
 
 Array CSGShape3D::get_meshes() const {
@@ -1642,6 +1702,8 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_face_material", "face"), &CSGShape3D::get_face_material);
 	ClassDB::bind_method(D_METHOD("get_vertices"), &CSGShape3D::get_vertices);
 	ClassDB::bind_method(D_METHOD("set_vertex_position", "from", "to"), &CSGShape3D::set_vertex_position);
+	ClassDB::bind_method(D_METHOD("calculate_cube_map", "faces"), &CSGShape3D::calculate_cube_map);
+	ClassDB::bind_method(D_METHOD("get_selected_faces", "faces"), &CSGShape3D::get_selected_faces);
 
 	ClassDB::bind_method(D_METHOD("get_meshes"), &CSGShape3D::get_meshes);
 
@@ -1901,7 +1963,7 @@ void CSGMesh3D::set_material(const Ref<Material> &p_material) {
 		return;
 	}
 	material = p_material;
-	rebuild_brush();
+	_make_painted();
 }
 
 Ref<Material> CSGMesh3D::get_material() const {
@@ -2110,7 +2172,7 @@ float CSGSphere3D::get_radius() const {
 
 void CSGSphere3D::set_radial_segments(const int p_radial_segments) {
 	radial_segments = p_radial_segments > 4 ? p_radial_segments : 4;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2120,7 +2182,7 @@ int CSGSphere3D::get_radial_segments() const {
 
 void CSGSphere3D::set_rings(const int p_rings) {
 	rings = p_rings > 1 ? p_rings : 1;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2140,7 +2202,7 @@ bool CSGSphere3D::get_smooth_faces() const {
 
 void CSGSphere3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	rebuild_brush();
+	_make_painted();
 }
 
 Ref<Material> CSGSphere3D::get_material() const {
@@ -2306,7 +2368,7 @@ bool CSGBox3D::_set(const StringName &p_name, const Variant &p_value) {
 
 void CSGBox3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2505,7 +2567,7 @@ float CSGCylinder3D::get_height() const {
 void CSGCylinder3D::set_sides(const int p_sides) {
 	ERR_FAIL_COND(p_sides < 3);
 	sides = p_sides;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2515,7 +2577,7 @@ int CSGCylinder3D::get_sides() const {
 
 void CSGCylinder3D::set_cone(const bool p_cone) {
 	cone = p_cone;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2534,7 +2596,7 @@ bool CSGCylinder3D::get_smooth_faces() const {
 
 void CSGCylinder3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	rebuild_brush();
+	_make_painted();
 }
 
 Ref<Material> CSGCylinder3D::get_material() const {
@@ -2709,7 +2771,7 @@ void CSGTorus3D::_bind_methods() {
 
 void CSGTorus3D::set_inner_radius(const float p_inner_radius) {
 	inner_radius = p_inner_radius;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2719,7 +2781,7 @@ float CSGTorus3D::get_inner_radius() const {
 
 void CSGTorus3D::set_outer_radius(const float p_outer_radius) {
 	outer_radius = p_outer_radius;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2730,7 +2792,7 @@ float CSGTorus3D::get_outer_radius() const {
 void CSGTorus3D::set_sides(const int p_sides) {
 	ERR_FAIL_COND(p_sides < 3);
 	sides = p_sides;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2741,7 +2803,7 @@ int CSGTorus3D::get_sides() const {
 void CSGTorus3D::set_ring_sides(const int p_ring_sides) {
 	ERR_FAIL_COND(p_ring_sides < 3);
 	ring_sides = p_ring_sides;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2761,7 +2823,7 @@ bool CSGTorus3D::get_smooth_faces() const {
 
 void CSGTorus3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	rebuild_brush();
+	_make_painted();
 }
 
 Ref<Material> CSGTorus3D::get_material() const {
@@ -3164,7 +3226,7 @@ void CSGPolygon3D::_validate_property(PropertyInfo &p_property) const {
 }
 
 void CSGPolygon3D::_path_changed() {
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3259,7 +3321,7 @@ void CSGPolygon3D::_bind_methods() {
 
 void CSGPolygon3D::set_polygon(const Vector<Vector2> &p_polygon) {
 	polygon = p_polygon;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3269,7 +3331,7 @@ Vector<Vector2> CSGPolygon3D::get_polygon() const {
 
 void CSGPolygon3D::set_mode(Mode p_mode) {
 	mode = p_mode;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 	notify_property_list_changed();
 }
@@ -3281,7 +3343,7 @@ CSGPolygon3D::Mode CSGPolygon3D::get_mode() const {
 void CSGPolygon3D::set_depth(const float p_depth) {
 	ERR_FAIL_COND(p_depth < 0.001);
 	depth = p_depth;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3291,7 +3353,7 @@ float CSGPolygon3D::get_depth() const {
 
 void CSGPolygon3D::set_path_continuous_u(bool p_enable) {
 	path_continuous_u = p_enable;
-	rebuild_brush();
+	_make_painted();
 }
 
 bool CSGPolygon3D::is_path_continuous_u() const {
@@ -3300,7 +3362,7 @@ bool CSGPolygon3D::is_path_continuous_u() const {
 
 void CSGPolygon3D::set_path_u_distance(real_t p_path_u_distance) {
 	path_u_distance = p_path_u_distance;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3311,7 +3373,7 @@ real_t CSGPolygon3D::get_path_u_distance() const {
 void CSGPolygon3D::set_spin_degrees(const float p_spin_degrees) {
 	ERR_FAIL_COND(p_spin_degrees < 0.01 || p_spin_degrees > 360);
 	spin_degrees = p_spin_degrees;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3322,7 +3384,7 @@ float CSGPolygon3D::get_spin_degrees() const {
 void CSGPolygon3D::set_spin_sides(int p_spin_sides) {
 	ERR_FAIL_COND(p_spin_sides < 3);
 	spin_sides = p_spin_sides;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3332,7 +3394,7 @@ int CSGPolygon3D::get_spin_sides() const {
 
 void CSGPolygon3D::set_path_node(const NodePath &p_path) {
 	path_node = p_path;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3342,7 +3404,7 @@ NodePath CSGPolygon3D::get_path_node() const {
 
 void CSGPolygon3D::set_path_interval_type(PathIntervalType p_interval_type) {
 	path_interval_type = p_interval_type;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3352,7 +3414,7 @@ CSGPolygon3D::PathIntervalType CSGPolygon3D::get_path_interval_type() const {
 
 void CSGPolygon3D::set_path_interval(float p_interval) {
 	path_interval = p_interval;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3362,7 +3424,7 @@ float CSGPolygon3D::get_path_interval() const {
 
 void CSGPolygon3D::set_path_simplify_angle(float p_angle) {
 	path_simplify_angle = p_angle;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3372,7 +3434,7 @@ float CSGPolygon3D::get_path_simplify_angle() const {
 
 void CSGPolygon3D::set_path_rotation(PathRotation p_rotation) {
 	path_rotation = p_rotation;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3382,7 +3444,7 @@ CSGPolygon3D::PathRotation CSGPolygon3D::get_path_rotation() const {
 
 void CSGPolygon3D::set_path_rotation_accurate(bool p_enabled) {
 	path_rotation_accurate = p_enabled;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3392,7 +3454,7 @@ bool CSGPolygon3D::get_path_rotation_accurate() const {
 
 void CSGPolygon3D::set_path_local(bool p_enable) {
 	path_local = p_enable;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3402,7 +3464,7 @@ bool CSGPolygon3D::is_path_local() const {
 
 void CSGPolygon3D::set_path_joined(bool p_enable) {
 	path_joined = p_enable;
-	rebuild_brush();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -3421,7 +3483,7 @@ bool CSGPolygon3D::get_smooth_faces() const {
 
 void CSGPolygon3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	rebuild_brush();
+	_make_painted();
 }
 
 Ref<Material> CSGPolygon3D::get_material() const {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1105,6 +1105,9 @@ Dictionary CSGShape3D::get_csg_brush() {
 	}
 
 	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return p_brush_data;
+	}
 
 	if (n->faces.size() <= 0) {
 		return p_brush_data;
@@ -1228,6 +1231,7 @@ void CSGShape3D::rebuild_brush() {
 void CSGShape3D::set_uv_offsets(const Vector<int> &p_faces, const Vector2 &prev_offset, const Vector2 &p_offset) {
 	// Use the offset obtained from `get_uv_offsets` when selecting faces.
 	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
 	if (n->faces.is_empty()) {
 		return;
@@ -1249,6 +1253,9 @@ Vector2 CSGShape3D::get_uv_offsets(int p_face) {
 	}
 
 	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return Vector2(0.0, 0.0);
+	}
 
 	if (n->faces.is_empty()) {
 		return Vector2(0.0, 0.0);
@@ -1274,6 +1281,7 @@ Vector2 CSGShape3D::get_uv_offsets(int p_face) {
 
 void CSGShape3D::set_uv_scale(const Vector<int> &p_faces, const Vector2 &prev_scale, const Vector2 &p_scale) {
 	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
 	if (n->faces.is_empty()) {
 		return;
@@ -1311,6 +1319,9 @@ Vector2 CSGShape3D::get_uv_scale(int p_face) {
 	}
 
 	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return Vector2(1.0, 1.0);
+	}
 
 	if (n->faces.is_empty()) {
 		return Vector2(1.0, 1.0);
@@ -1339,6 +1350,7 @@ Vector2 CSGShape3D::get_uv_scale(int p_face) {
 
 void CSGShape3D::rotate_uv(const Vector<int> &p_faces, const float angle) {
 	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
 	if (n->faces.is_empty()) {
 		return;
@@ -1357,6 +1369,7 @@ void CSGShape3D::rotate_uv(const Vector<int> &p_faces, const float angle) {
 
 void CSGShape3D::flip_x(const Vector<int> &p_faces) {
 	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
 	if (n->faces.is_empty()) {
 		return;
@@ -1377,6 +1390,7 @@ void CSGShape3D::flip_x(const Vector<int> &p_faces) {
 
 void CSGShape3D::flip_y(const Vector<int> &p_faces) {
 	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
 	if (n->faces.is_empty()) {
 		return;
@@ -1408,6 +1422,9 @@ bool CSGShape3D::resize_brush(const Vector3 &prev_size, const Vector3 &p_size) {
 	}
 
 	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return true;
+	}
 
 	if (n->faces.is_empty()) {
 		return false;
@@ -1428,6 +1445,7 @@ bool CSGShape3D::resize_brush(const Vector3 &prev_size, const Vector3 &p_size) {
 void CSGShape3D::set_csg_flat(bool p_mode) {
 	// This changes all faces so it can't be used with CSGCylinder3D.
 	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
 	if (n->faces.is_empty()) {
 		return;
@@ -1441,6 +1459,7 @@ void CSGShape3D::set_csg_flat(bool p_mode) {
 
 void CSGShape3D::set_face_material(const Vector<int> &p_faces, const Ref<Material> &p_material) {
 	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
 	if (n->faces.is_empty()) {
 		return;
@@ -1475,6 +1494,9 @@ void CSGShape3D::set_face_material(const Vector<int> &p_faces, const Ref<Materia
 Ref<Material> CSGShape3D::get_face_material(int p_face) {
 	// Using only one face as only one material will be returned.
 	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return nullptr;
+	}
 
 	if (n->faces.is_empty()) {
 		return nullptr;
@@ -1498,6 +1520,10 @@ Vector<Vector3> CSGShape3D::get_vertices() {
 
 	Vector<Vector3> vertices;
 
+	if (n == nullptr) {
+		return vertices;
+	}
+
 	for (int i = 0; i < n->faces.size(); i++) {
 		for (int j = 0; j < 3; j++) {
 			Vector3 v = n->faces[i].vertices[j];
@@ -1513,6 +1539,7 @@ Vector<Vector3> CSGShape3D::get_vertices() {
 
 void CSGShape3D::set_vertex_position(const Vector3 &curr_pos, const Vector3 &p_pos) {
 	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
 	if (n->faces.is_empty()) {
 		return;

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -123,7 +123,7 @@ protected:
 	void _notification(int p_what);
 	virtual CSGBrush *_build_brush() = 0;
 	void _make_dirty(bool p_parent_removing = false);
-	void _make_painted(bool p_paint = false);
+	void _make_painted(bool p_paint = false, bool p_parent_removing = false);
 	PackedStringArray get_configuration_warnings() const override;
 
 	static void _bind_methods();
@@ -154,6 +154,10 @@ public:
 	void set_vertex_position(const Vector3 &curr_pos, const Vector3 &p_pos);
 	void calculate_cube_map(const Vector<int> &p_faces);
 	Vector<Vector3> get_selected_faces(const Vector<int> &p_faces);
+	Vector<Vector3> get_csg_faces_anchor_points();
+	int get_csg_num_faces();
+	void set_csg_face_smooth(const Vector<int> &p_faces, bool p_smooth);
+	bool is_csg_face_smooth(int p_face);
 
 	Array get_meshes() const;
 	void update_shape();

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -159,6 +159,7 @@ public:
 	void set_csg_face_smooth(const Vector<int> &p_faces, bool p_smooth);
 	bool is_csg_face_smooth(int p_face);
 	bool is_painted() const;
+	Vector<int> get_all_csg_faces() const;
 
 	Array get_meshes() const;
 	void update_shape();

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -147,8 +147,8 @@ public:
 	void flip_x(const Vector<int> &p_faces);
 	void flip_y(const Vector<int> &p_faces);
 	void calculate_cube_map(const Vector<int> &p_faces);
-	void set_csg_face_smooth(const Vector<int> &p_faces, bool p_smooth);
-	bool is_csg_face_smooth(int p_face);
+	void set_csg_face_smooth_group(const Vector<int> &p_faces, int p_smooth);
+	int get_csg_face_smooth_group(int p_face);
 	// These change material.
 	void set_face_material(const Vector<int> &p_faces, const Ref<Material> &p_material);
 	Ref<Material> get_face_material(int p_face);
@@ -251,7 +251,7 @@ class CSGPrimitive3D : public CSGShape3D {
 
 protected:
 	bool flip_faces;
-	CSGBrush *_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials);
+	CSGBrush *_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<int> &p_smooth, const Vector<Ref<Material>> &p_materials);
 	static void _bind_methods();
 
 public:

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -66,7 +66,6 @@ private:
 
 	bool dirty = false;
 	bool painted = false;
-	bool first_go = true;
 	bool last_visible = false;
 	float snap = 0.001;
 
@@ -125,7 +124,6 @@ protected:
 	virtual CSGBrush *_build_brush() = 0;
 	void _make_dirty(bool p_parent_removing = false);
 	void _make_painted(bool p_paint = false);
-	void _allow_editing();
 	PackedStringArray get_configuration_warnings() const override;
 
 	static void _bind_methods();
@@ -136,6 +134,7 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:
+	void get_csg_children_recursive(Vector<CSGShape3D *> &p_nodes);
 	Dictionary get_csg_brush();
 	void set_csg_brush(const Dictionary &p_brush_data);
 	void rebuild_brush();
@@ -153,6 +152,8 @@ public:
 	Ref<Material> get_face_material(int p_face);
 	Vector<Vector3> get_vertices();
 	void set_vertex_position(const Vector3 &curr_pos, const Vector3 &p_pos);
+	void calculate_cube_map(const Vector<int> &p_faces);
+	Vector<Vector3> get_selected_faces(const Vector<int> &p_faces);
 
 	Array get_meshes() const;
 	void update_shape();

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -136,6 +136,8 @@ protected:
 public:
 	void get_csg_children_recursive(Vector<CSGShape3D *> &p_nodes);
 	void rebuild_brush();
+	Dictionary get_csg_brush();
+	void set_csg_brush(const Dictionary &p_brush_data);
 	// These work on selected faces.
 	void set_uv_offsets(const Vector<int> &p_faces, const Vector2 &prev_offset, const Vector2 &p_offset);
 	Vector2 get_uv_offsets(int p_face);
@@ -256,9 +258,6 @@ protected:
 public:
 	void set_flip_faces(bool p_invert);
 	bool get_flip_faces();
-
-	Dictionary get_csg_brush();
-	void set_csg_brush(const Dictionary &p_brush_data);
 
 	CSGPrimitive3D();
 };

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -136,6 +136,7 @@ protected:
 public:
 	void get_csg_children_recursive(Vector<CSGShape3D *> &p_nodes);
 	void rebuild_brush();
+	void brush_modified();
 	Dictionary get_csg_brush();
 	void set_csg_brush(const Dictionary &p_brush_data);
 	// These work on selected faces.
@@ -147,6 +148,7 @@ public:
 	void flip_x(const Vector<int> &p_faces);
 	void flip_y(const Vector<int> &p_faces);
 	void calculate_cube_map(const Vector<int> &p_faces);
+	void calculate_cylinder_map(const Vector<int> &p_faces);
 	void set_csg_face_smooth_group(const Vector<int> &p_faces, int p_smooth);
 	int get_csg_face_smooth_group(int p_face);
 	// These change material.
@@ -251,7 +253,7 @@ class CSGPrimitive3D : public CSGShape3D {
 
 protected:
 	bool flip_faces;
-	CSGBrush *_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<int> &p_smooth, const Vector<Ref<Material>> &p_materials);
+	CSGBrush *_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<int> &p_smooth, const Vector<Ref<Material>> &p_materials, const Vector<int> &ngons);
 	static void _bind_methods();
 
 public:

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -135,8 +135,6 @@ protected:
 
 public:
 	void get_csg_children_recursive(Vector<CSGShape3D *> &p_nodes);
-	Dictionary get_csg_brush();
-	void set_csg_brush(const Dictionary &p_brush_data);
 	void rebuild_brush();
 	// These work on selected faces.
 	void set_uv_offsets(const Vector<int> &p_faces, const Vector2 &prev_offset, const Vector2 &p_offset);
@@ -258,6 +256,9 @@ protected:
 public:
 	void set_flip_faces(bool p_invert);
 	bool get_flip_faces();
+
+	Dictionary get_csg_brush();
+	void set_csg_brush(const Dictionary &p_brush_data);
 
 	CSGPrimitive3D();
 };

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -136,22 +136,22 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:
-	Dictionary get_csg_brush() const;
+	Dictionary get_csg_brush();
 	void set_csg_brush(const Dictionary &p_brush_data);
 	void rebuild_brush();
 
 	void set_uv_offsets(const Vector<int> &p_faces, const Vector2 &prev_offset, const Vector2 &p_offset);
-	Vector2 get_uv_offsets(int p_face) const;
+	Vector2 get_uv_offsets(int p_face);
 	void set_uv_scale(const Vector<int> &p_faces, const Vector2 &prev_scale, const Vector2 &p_scale);
-	Vector2 get_uv_scale(int p_face) const;
+	Vector2 get_uv_scale(int p_face);
 	void rotate_uv(const Vector<int> &p_faces, const float angle);
 	void flip_x(const Vector<int> &p_faces);
 	void flip_y(const Vector<int> &p_faces);
 	bool resize_brush(const Vector3 &prev_size, const Vector3 &p_size);
 	void set_csg_flat(bool p_mode);
 	void set_face_material(const Vector<int> &p_faces, const Ref<Material> &p_material);
-	Ref<Material> get_face_material(int p_face) const;
-	Vector<Vector3> get_vertices() const;
+	Ref<Material> get_face_material(int p_face);
+	Vector<Vector3> get_vertices();
 	void set_vertex_position(const Vector3 &curr_pos, const Vector3 &p_pos);
 
 	Array get_meshes() const;

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -138,7 +138,7 @@ public:
 	Dictionary get_csg_brush();
 	void set_csg_brush(const Dictionary &p_brush_data);
 	void rebuild_brush();
-
+	// These work on selected faces.
 	void set_uv_offsets(const Vector<int> &p_faces, const Vector2 &prev_offset, const Vector2 &p_offset);
 	Vector2 get_uv_offsets(int p_face);
 	void set_uv_scale(const Vector<int> &p_faces, const Vector2 &prev_scale, const Vector2 &p_scale);
@@ -146,20 +146,27 @@ public:
 	void rotate_uv(const Vector<int> &p_faces, const float angle);
 	void flip_x(const Vector<int> &p_faces);
 	void flip_y(const Vector<int> &p_faces);
-	bool resize_brush(const Vector3 &prev_size, const Vector3 &p_size);
-	void set_csg_flat(bool p_mode);
-	void set_face_material(const Vector<int> &p_faces, const Ref<Material> &p_material);
-	Ref<Material> get_face_material(int p_face);
-	Vector<Vector3> get_vertices();
-	void set_vertex_position(const Vector3 &curr_pos, const Vector3 &p_pos);
 	void calculate_cube_map(const Vector<int> &p_faces);
-	Vector<Vector3> get_selected_faces(const Vector<int> &p_faces);
-	Vector<Vector3> get_csg_faces_anchor_points();
-	int get_csg_num_faces();
 	void set_csg_face_smooth(const Vector<int> &p_faces, bool p_smooth);
 	bool is_csg_face_smooth(int p_face);
-	bool is_painted() const;
+	// These change material.
+	void set_face_material(const Vector<int> &p_faces, const Ref<Material> &p_material);
+	Ref<Material> get_face_material(int p_face);
+	// These affect the entire brush.
+	bool resize_brush(const Vector3 &prev_size, const Vector3 &p_size);
+	void set_csg_invert();
+	void set_csg_flat(bool p_mode);
+	// These affect vertices.
+	Vector<Vector3> get_vertices();
+	void set_vertex_position(const Vector3 &curr_pos, const Vector3 &p_pos);
+	// These are helper methods for UX.
+	Vector<Vector3> get_selected_faces(const Vector<int> &p_faces);
+	int get_csg_num_faces();
 	Vector<int> get_all_csg_faces();
+	Vector<int> get_faces_from_ngon(int p_ngon);
+	TypedArray<Vector<Vector3>> get_csg_ngon_colliders();
+	Vector<Vector3> get_all_ngon_lines();
+	bool is_painted() const;
 
 	Array get_meshes() const;
 	void update_shape();

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -154,7 +154,7 @@ public:
 	Ref<Material> get_face_material(int p_face);
 	// These affect the entire brush.
 	bool resize_brush(const Vector3 &prev_size, const Vector3 &p_size);
-	void set_csg_invert();
+	void set_csg_invert(bool inv_val);
 	void set_csg_flat(bool p_mode);
 	// These affect vertices.
 	Vector<Vector3> get_vertices();

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -158,6 +158,7 @@ public:
 	int get_csg_num_faces();
 	void set_csg_face_smooth(const Vector<int> &p_faces, bool p_smooth);
 	bool is_csg_face_smooth(int p_face);
+	bool is_painted() const;
 
 	Array get_meshes() const;
 	void update_shape();

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -156,6 +156,7 @@ public:
 	Ref<Material> get_face_material(int p_face);
 	// These affect the entire brush.
 	bool resize_brush(const Vector3 &prev_size, const Vector3 &p_size);
+	void resize_brush_rework();
 	void set_csg_invert(bool inv_val);
 	void set_csg_flat(bool p_mode);
 	// These affect vertices.

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -165,7 +165,6 @@ public:
 	Vector<int> get_all_csg_faces();
 	Vector<int> get_faces_from_ngon(int p_ngon);
 	TypedArray<Vector<Vector3>> get_csg_ngon_colliders();
-	Vector<Vector3> get_all_ngon_lines();
 	bool is_painted() const;
 
 	Array get_meshes() const;

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -65,6 +65,8 @@ private:
 	AABB node_aabb;
 
 	bool dirty = false;
+	bool painted = false;
+	bool first_go = true;
 	bool last_visible = false;
 	float snap = 0.001;
 
@@ -122,7 +124,8 @@ protected:
 	void _notification(int p_what);
 	virtual CSGBrush *_build_brush() = 0;
 	void _make_dirty(bool p_parent_removing = false);
-	void _make_painted();
+	void _make_painted(bool p_paint = false);
+	void _allow_editing();
 	PackedStringArray get_configuration_warnings() const override;
 
 	static void _bind_methods();
@@ -137,7 +140,19 @@ public:
 	void set_csg_brush(const Dictionary &p_brush_data);
 	void rebuild_brush();
 
+	void set_uv_offsets(const Vector<int> &p_faces, const Vector2 &prev_offset, const Vector2 &p_offset);
+	Vector2 get_uv_offsets(int p_face) const;
+	void set_uv_scale(const Vector<int> &p_faces, const Vector2 &prev_scale, const Vector2 &p_scale);
+	Vector2 get_uv_scale(int p_face) const;
 	void rotate_uv(const Vector<int> &p_faces, const float angle);
+	void flip_x(const Vector<int> &p_faces);
+	void flip_y(const Vector<int> &p_faces);
+	bool resize_brush(const Vector3 &prev_size, const Vector3 &p_size);
+	void set_csg_flat(bool p_mode);
+	void set_face_material(const Vector<int> &p_faces, const Ref<Material> &p_material);
+	Ref<Material> get_face_material(int p_face) const;
+	Vector<Vector3> get_vertices() const;
+	void set_vertex_position(const Vector3 &curr_pos, const Vector3 &p_pos);
 
 	Array get_meshes() const;
 	void update_shape();

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -159,7 +159,7 @@ public:
 	void set_csg_face_smooth(const Vector<int> &p_faces, bool p_smooth);
 	bool is_csg_face_smooth(int p_face);
 	bool is_painted() const;
-	Vector<int> get_all_csg_faces() const;
+	Vector<int> get_all_csg_faces();
 
 	Array get_meshes() const;
 	void update_shape();

--- a/modules/csg/doc_classes/CSGPrimitive3D.xml
+++ b/modules/csg/doc_classes/CSGPrimitive3D.xml
@@ -11,6 +11,16 @@
 		<link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
 	</tutorials>
 	<members>
+		<member name="_csg_brush" type="Dictionary" setter="set_csg_brush" getter="get_csg_brush" default="{ painted : false }">
+			The CSGBrush of the node as a [Dictionary] containing the following entries:
+			- [code]material_id[/code]: PackedByteArray with the id of the material assigned to each face. See [code]materials[/code].
+			- [code]vertices[/code]: [PackedVector3Array] containing the position of the triangles that make up the CSGBrush, must be divisible by 3.
+			- [code]uvs[/code]: [PackedVector2Array] containing the uv of the triangles of the CSGBrush, must be divisible by 3.
+			- [code]smooth[/code]: PackedByteArray with the smoothing groups of the faces of the CSGBrush. Currently [code]0[/code] disables the effect and any value above enables it.
+			- [code]materials[/code]: [Array] of [Material] of the CSGBrush.
+			- [code]painted[/code]: when set to [code]true[/code], tells the engine not to rebuild the CSGBrush.
+			- [code]ngons[/code]: [PackedInt32Array] with the ngons assigned to each face.
+		</member>
 		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces" default="false">
 			If set, the order of the vertices in each triangle are reversed resulting in the backside of the mesh being drawn.
 		</member>

--- a/modules/csg/doc_classes/CSGPrimitive3D.xml
+++ b/modules/csg/doc_classes/CSGPrimitive3D.xml
@@ -11,16 +11,6 @@
 		<link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
 	</tutorials>
 	<members>
-		<member name="_csg_brush" type="Dictionary" setter="set_csg_brush" getter="get_csg_brush" default="{ painted : false }">
-			The CSGBrush of the node as a [Dictionary] containing the following entries:
-			- [code]material_id[/code]: PackedByteArray with the id of the material assigned to each face. See [code]materials[/code].
-			- [code]vertices[/code]: [PackedVector3Array] containing the position of the triangles that make up the CSGBrush, must be divisible by 3.
-			- [code]uvs[/code]: [PackedVector2Array] containing the uv of the triangles of the CSGBrush, must be divisible by 3.
-			- [code]smooth[/code]: PackedByteArray with the smoothing groups of the faces of the CSGBrush. Currently [code]0[/code] disables the effect and any value above enables it.
-			- [code]materials[/code]: [Array] of [Material] of the CSGBrush.
-			- [code]painted[/code]: when set to [code]true[/code], tells the engine not to rebuild the CSGBrush.
-			- [code]ngons[/code]: [PackedInt32Array] with the ngons assigned to each face.
-		</member>
 		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces" default="false">
 			If set, the order of the vertices in each triangle are reversed resulting in the backside of the mesh being drawn.
 		</member>

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -29,6 +29,20 @@
 				[b]Note:[/b] CSG mesh data updates are deferred, which means they are updated with a delay of one rendered frame. To avoid getting an empty mesh or outdated mesh data, make sure to call [code]await get_tree().process_frame[/code] before using [method bake_static_mesh] in [method Node._ready] or after changing properties on the [CSGShape3D].
 			</description>
 		</method>
+		<method name="flip_x">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<description>
+				Flips [param faces] in X.
+			</description>
+		</method>
+		<method name="flip_y">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<description>
+				Flips [param faces] in Y.
+			</description>
+		</method>
 		<method name="get_collision_layer_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
@@ -43,6 +57,26 @@
 				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
+		<method name="get_csg_brush" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns the CSGBrush of the node as a [Dictionary] containing the following entries:
+				- [code]material_id[/code]: Vector<uint8_t> with the id of the material assigned to each face. See [code]materials[/code].
+				- [code]vertices[/code]: [PackedVector3Array] containing the position of the triangles that make up the CSGBrush, must be divisible by 3.
+				- [code]uvs[/code]: [PackedVector2Array] containing the uv of the triangles of the CSGBrush, must be divisible by 3.
+				- [code]smooth[/code]: Vector<uint8_t> with the smoothing groups of the faces of the CSGBrush. Currently [code]0[/code] disables the effect and any value above enables it.
+				- [code]inverted[/code]: [bool] determining the [code]invert[/code] of all the faces.
+				- [code]materials[/code]: [Array] of [Material] of the CSGBrush.
+				- [code]painted[/code]: when set to [code]true[/code], tells the engine not to rebuild the CSGBrush.
+			</description>
+		</method>
+		<method name="get_face_material" qualifiers="const">
+			<return type="Material" />
+			<param index="0" name="face" type="int" />
+			<description>
+				Gets the material of [param face] in the CSGBrush.
+			</description>
+		</method>
 		<method name="get_meshes" qualifiers="const">
 			<return type="Array" />
 			<description>
@@ -50,10 +84,56 @@
 				[b]Note:[/b] CSG mesh data updates are deferred, which means they are updated with a delay of one rendered frame. To avoid getting an empty shape or outdated mesh data, make sure to call [code]await get_tree().process_frame[/code] before using [method get_meshes] in [method Node._ready] or after changing properties on the [CSGShape3D].
 			</description>
 		</method>
+		<method name="get_uv_offsets" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="face" type="int" />
+			<description>
+				Returns the calculated offset of the UVs of the [param face] of the CSGBrush.
+			</description>
+		</method>
+		<method name="get_uv_scale" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="face" type="int" />
+			<description>
+				Returns the calculated scale of the UVs of the [param face] of the CSGBrush.
+			</description>
+		</method>
+		<method name="get_vertices" qualifiers="const">
+			<return type="PackedVector3Array" />
+			<description>
+				Returns a [PackedVector3Array] with the positions of the vertices of the CSGBrush. This method ignores duplicated positions and is intended to be used with [method set_vertex_position].
+			</description>
+		</method>
 		<method name="is_root_shape" qualifiers="const">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if this is a root shape and is thus the object that is rendered.
+			</description>
+		</method>
+		<method name="rebuild_brush">
+			<return type="void" />
+			<description>
+				Rebuilds the CSGBrush based on the properties of the CSG node. Overrides any changes to the faces or vertices.
+			</description>
+		</method>
+		<method name="resize_brush">
+			<return type="bool" />
+			<param index="0" name="prev_size" type="Vector3" />
+			<param index="1" name="size" type="Vector3" />
+			<description>
+				Resizes the CSGBrush from [param prev_size] to [param size].
+				For a [CSGBox3D], [param prev_size] would be the [code]size[/code] property, and [param size] the new dimensions.
+				Note: [param size] and [param prev_size] must never have a value equal or lower than [code]0[/code].
+			</description>
+		</method>
+		<method name="rotate_uv">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<param index="1" name="angle" type="float" />
+			<description>
+				Rotates [param faces] of the CSGBrush by [param angle].
+				[param faces]: must be a [PackedInt32Array] containing valid index of faces in the CSGBrush.
+				[param angle] must be in radians.
 			</description>
 		</method>
 		<method name="set_collision_layer_value">
@@ -70,6 +150,59 @@
 			<param index="1" name="value" type="bool" />
 			<description>
 				Based on [param value], enables or disables the specified layer in the [member collision_mask], given a [param layer_number] between 1 and 32.
+			</description>
+		</method>
+		<method name="set_csg_brush">
+			<return type="void" />
+			<param index="0" name="csg_brush" type="Dictionary" />
+			<description>
+				Can be used to manually set the CSGBrush.
+				See [method get_csg_brush]
+			</description>
+		</method>
+		<method name="set_face_material">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<param index="1" name="material" type="Material" />
+			<description>
+				Sets [param material] on [param faces].
+			</description>
+		</method>
+		<method name="set_uv_offsets">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<param index="1" name="prev_offset" type="Vector2" />
+			<param index="2" name="offset" type="Vector2" />
+			<description>
+				Sets the UVs of [param faces] of the CSGBrush using [param offset].
+				Usage:
+				[code]
+				# Offset the first and second faces of CSGBrush.
+				set_uv_offsets(PackedInt32Array(0, 1), get_uv_offsets(PackedInt32Array(0, 1)), Vector2(1.0, 1.0))
+				[/code]
+			</description>
+		</method>
+		<method name="set_uv_scale">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<param index="1" name="prev_scale" type="Vector2" />
+			<param index="2" name="scale" type="Vector2" />
+			<description>
+				Sets the UVs of [param faces] of the CSGBrush using [param scale].
+				Usage:
+				[code]
+				# Scale the first and second faces of CSGBrush.
+				set_uv_scale(PackedInt32Array(0, 1), get_uv_scale(PackedInt32Array(0, 1)), Vector2(2.0, 2.0))
+				[/code]
+				Note: The values of scale can never be ZERO.
+			</description>
+		</method>
+		<method name="set_vertex_position">
+			<return type="void" />
+			<param index="0" name="from" type="Vector3" />
+			<param index="1" name="to" type="Vector3" />
+			<description>
+				Sets all the vertices of the CSGBrush in position [param from] to [param to].
 			</description>
 		</method>
 	</methods>

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -244,7 +244,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="_csg_brush" type="Dictionary" setter="set_csg_brush" getter="get_csg_brush" default="{&quot;painted&quot;: false }">
+		<member name="_csg_brush" type="Dictionary" setter="set_csg_brush" getter="get_csg_brush" default="{ &quot;painted&quot;: false }">
 			The CSGBrush of the node as a [Dictionary] containing the following entries:
 			- [code]material_id[/code]: PackedByteArray with the id of the material assigned to each face. See [code]materials[/code].
 			- [code]vertices[/code]: [PackedVector3Array] containing the position of the triangles that make up the CSGBrush, must be divisible by 3.

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -33,7 +33,7 @@
 			<return type="void" />
 			<description>
 				Forces an update of the root csg shape visuals. When used on a root shape, it rebuilds the brush.
-				This is meant to be called after [code]set_csg_brush[/code].
+				This is meant to be called after [code]set_csg_brush[/code] in undo operations.
 			</description>
 		</method>
 		<method name="calculate_cube_map">
@@ -41,6 +41,7 @@
 			<param index="0" name="faces" type="PackedInt32Array" />
 			<description>
 				Generates cube map UVs for the selected faces. This is a simple unwrapping that calculates the UVs based on the direction of the face.
+				[param faces]: must be a [PackedInt32Array] containing valid index of faces in the CSGBrush.
 			</description>
 		</method>
 		<method name="calculate_cylinder_map">
@@ -48,6 +49,7 @@
 			<param index="0" name="faces" type="PackedInt32Array" />
 			<description>
 				Generates cylinder UVs for the selected faces. This is a simple unwrapping that calculates the side UVs based on the angle from the center.
+				[param faces]: must be a [PackedInt32Array] containing valid index of faces in the CSGBrush.
 			</description>
 		</method>
 		<method name="flip_x">
@@ -55,6 +57,7 @@
 			<param index="0" name="faces" type="PackedInt32Array" />
 			<description>
 				Flips [param faces] in X.
+				[param faces]: must be a [PackedInt32Array] containing valid index of faces in the CSGBrush.
 			</description>
 		</method>
 		<method name="flip_y">
@@ -62,6 +65,7 @@
 			<param index="0" name="faces" type="PackedInt32Array" />
 			<description>
 				Flips [param faces] in Y.
+				[param faces]: must be a [PackedInt32Array] containing valid index of faces in the CSGBrush.
 			</description>
 		</method>
 		<method name="get_all_csg_faces">
@@ -130,6 +134,7 @@
 			<param index="0" name="faces" type="PackedInt32Array" />
 			<description>
 				Returns the vertices used to generate the selected faces. This is intended for generating a mesh to display the selected faces in the editor.
+				[param faces]: must be a [PackedInt32Array] containing valid index of faces in the CSGBrush.
 			</description>
 		</method>
 		<method name="get_uv_offsets">
@@ -161,7 +166,7 @@
 		<method name="rebuild_brush">
 			<return type="void" />
 			<description>
-				Rebuilds the CSGBrush based on the properties of the CSG node. Overrides any changes to the faces or vertices. Internally sets [code]painted[/code] to false, unlocking features like CSGCylinder [code]sides[/code] that do not update when the brush is painted.
+				Rebuilds the CSGBrush based on the properties of the CSG node. Overrides any changes to the faces or vertices. Internally sets [code]painted[/code] to false.
 			</description>
 		</method>
 		<method name="resize_brush">
@@ -206,6 +211,7 @@
 			<param index="1" name="smooth" type="int" />
 			<description>
 				Sets the faces smoothing. A value of 0 will make the face flat while any value above will make it smooth. Faces of different brushes with the same smooth group will blend together.
+				[param faces]: must be a [PackedInt32Array] containing valid index of faces in the CSGBrush.
 			</description>
 		</method>
 		<method name="set_face_material">
@@ -214,6 +220,7 @@
 			<param index="1" name="material" type="Material" />
 			<description>
 				Sets [param material] on [param faces].
+				[param faces]: must be a [PackedInt32Array] containing valid index of faces in the CSGBrush.
 			</description>
 		</method>
 		<method name="set_uv_offsets">
@@ -223,6 +230,7 @@
 			<param index="2" name="p_offset" type="Vector2" />
 			<description>
 				Sets the UVs of [param faces] of the CSGBrush using [param p_offset].
+				[param faces]: must be a [PackedInt32Array] containing valid index of faces in the CSGBrush.
 				Usage:
 				[code]
 				# Offset the first and second faces of CSGBrush.
@@ -238,6 +246,7 @@
 			<param index="2" name="p_scale" type="Vector2" />
 			<description>
 				Sets the UVs of [param faces] of the CSGBrush using [param p_scale].
+				[param faces]: must be a [PackedInt32Array] containing valid index of faces in the CSGBrush.
 				Usage:
 				[code]
 				# Scale the first and second faces of CSGBrush.
@@ -263,10 +272,10 @@
 			- [code]material_id[/code]: PackedByteArray with the id of the material assigned to each face. See [code]materials[/code].
 			- [code]vertices[/code]: [PackedVector3Array] containing the position of the triangles that make up the CSGBrush, must be divisible by 3.
 			- [code]uvs[/code]: [PackedVector2Array] containing the uv of the triangles of the CSGBrush, must be divisible by 3.
-			- [code]smooth[/code]: PackedByteArray with the smoothing groups of the faces of the CSGBrush. Currently [code]0[/code] disables the effect and any value above enables it.
+			- [code]smooth[/code]: PackedByteArray with the smoothing groups of the faces of the CSGBrush. A value of [code]0[/code] disables the effect and any value above enables it. Faces of different brushes with the same smooth group will blend together.
 			- [code]inverted[/code]: needed since flip_faces is a property of [CSGPrimitive3D] and not [CSGShape3D].
 			- [code]materials[/code]: [Array] of [Material] of the CSGBrush.
-			- [code]painted[/code]: when set to [code]true[/code], tells the engine not to rebuild the CSGBrush.
+			- [code]painted[/code]: when set to [code]true[/code], tells the engine not to rebuild the CSGBrush. Must always be true for this to work.
 			- [code]ngons[/code]: [PackedInt32Array] with the ngons assigned to each face.
 		</member>
 		<member name="autosmooth" type="bool" setter="set_autosmooth" getter="is_autosmooth" default="false">

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -71,12 +71,6 @@
 				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="get_csg_ngon_colliders">
-			<return type="Array[PackedVector3Array]" />
-			<description>
-				Returns an array of triangles for creating colliders for gizmos.
-			</description>
-		</method>
 		<method name="get_csg_num_faces">
 			<return type="int" />
 			<description>

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -61,10 +61,10 @@
 			<return type="Dictionary" />
 			<description>
 				Returns the CSGBrush of the node as a [Dictionary] containing the following entries:
-				- [code]material_id[/code]: Vector<uint8_t> with the id of the material assigned to each face. See [code]materials[/code].
+				- [code]material_id[/code]: PackedByteArray with the id of the material assigned to each face. See [code]materials[/code].
 				- [code]vertices[/code]: [PackedVector3Array] containing the position of the triangles that make up the CSGBrush, must be divisible by 3.
 				- [code]uvs[/code]: [PackedVector2Array] containing the uv of the triangles of the CSGBrush, must be divisible by 3.
-				- [code]smooth[/code]: Vector<uint8_t> with the smoothing groups of the faces of the CSGBrush. Currently [code]0[/code] disables the effect and any value above enables it.
+				- [code]smooth[/code]: PackedByteArray with the smoothing groups of the faces of the CSGBrush. Currently [code]0[/code] disables the effect and any value above enables it.
 				- [code]inverted[/code]: [bool] determining the [code]invert[/code] of all the faces.
 				- [code]materials[/code]: [Array] of [Material] of the CSGBrush.
 				- [code]painted[/code]: when set to [code]true[/code], tells the engine not to rebuild the CSGBrush.

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -71,6 +71,12 @@
 				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
+		<method name="get_csg_ngon_colliders">
+			<return type="PackedVector3Array[]" />
+			<description>
+				Returns an array of triangles for creating colliders for gizmos.
+			</description>
+		</method>
 		<method name="get_csg_num_faces">
 			<return type="int" />
 			<description>
@@ -238,7 +244,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="_csg_brush" type="Dictionary" setter="set_csg_brush" getter="get_csg_brush" default="{ painted : false }">
+		<member name="_csg_brush" type="Dictionary" setter="set_csg_brush" getter="get_csg_brush" default="{&quot;painted&quot;: false }">
 			The CSGBrush of the node as a [Dictionary] containing the following entries:
 			- [code]material_id[/code]: PackedByteArray with the id of the material assigned to each face. See [code]materials[/code].
 			- [code]vertices[/code]: [PackedVector3Array] containing the position of the triangles that make up the CSGBrush, must be divisible by 3.

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -238,6 +238,17 @@
 		</method>
 	</methods>
 	<members>
+		<member name="_csg_brush" type="Dictionary" setter="set_csg_brush" getter="get_csg_brush" default="{ painted : false }">
+			The CSGBrush of the node as a [Dictionary] containing the following entries:
+			- [code]material_id[/code]: PackedByteArray with the id of the material assigned to each face. See [code]materials[/code].
+			- [code]vertices[/code]: [PackedVector3Array] containing the position of the triangles that make up the CSGBrush, must be divisible by 3.
+			- [code]uvs[/code]: [PackedVector2Array] containing the uv of the triangles of the CSGBrush, must be divisible by 3.
+			- [code]smooth[/code]: PackedByteArray with the smoothing groups of the faces of the CSGBrush. Currently [code]0[/code] disables the effect and any value above enables it.
+			- [code]inverted[/code]: needed since flip_faces is a property of [CSGPrimitive3D] and not [CSGShape3D].
+			- [code]materials[/code]: [Array] of [Material] of the CSGBrush.
+			- [code]painted[/code]: when set to [code]true[/code], tells the engine not to rebuild the CSGBrush.
+			- [code]ngons[/code]: [PackedInt32Array] with the ngons assigned to each face.
+		</member>
 		<member name="autosmooth" type="bool" setter="set_autosmooth" getter="is_autosmooth" default="false">
 			Enables automatic smoothing. This overrides any smoothing on the CSG node and instead uses [member smoothing_angle] to calculate normals based on the angle between faces.
 			Children of a [CSGCombiner3D] node will be treated as a single mesh.

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -50,6 +50,13 @@
 				Flips [param faces] in Y.
 			</description>
 		</method>
+		<method name="get_all_csg_faces">
+			<return type="PackedInt32Array" />
+			<description>
+				Returns a [PackedInt32Array] of all the faces of the CSGBrush, with each face being represented by a number.
+				Equivalent to doing [code]range(get_csg_num_faces())[/code].
+			</description>
+		</method>
 		<method name="get_collision_layer_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
@@ -64,10 +71,10 @@
 				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="get_csg_faces_anchor_points">
-			<return type="PackedVector3Array" />
+		<method name="get_csg_ngon_colliders">
+			<return type="Array[PackedVector3Array]" />
 			<description>
-				Returns the center of each face for displaying anchors.
+				Returns an array of triangles for creating colliders for gizmos.
 			</description>
 		</method>
 		<method name="get_csg_num_faces">
@@ -81,6 +88,13 @@
 			<param index="0" name="face" type="int" />
 			<description>
 				Gets the material of [param face] in the CSGBrush.
+			</description>
+		</method>
+		<method name="get_faces_from_ngon">
+			<return type="PackedInt32Array" />
+			<param index="0" name="p_ngon" type="int" />
+			<description>
+				Returns the id of the faces assigned to ngon [param p_ngon].
 			</description>
 		</method>
 		<method name="get_meshes" qualifiers="const">
@@ -133,7 +147,7 @@
 		<method name="rebuild_brush">
 			<return type="void" />
 			<description>
-				Rebuilds the CSGBrush based on the properties of the CSG node. Overrides any changes to the faces or vertices.
+				Rebuilds the CSGBrush based on the properties of the CSG node. Overrides any changes to the faces or vertices. Internally sets [code]painted[/code] to false, unlocking features like CSGCylinder [code]sides[/code] that do not update when the brush is painted.
 			</description>
 		</method>
 		<method name="resize_brush">
@@ -198,7 +212,8 @@
 				Usage:
 				[code]
 				# Offset the first and second faces of CSGBrush.
-				set_uv_offsets(PackedInt32Array(0, 1), get_uv_offsets(PackedInt32Array(0, 1)), Vector2(1.0, 1.0))
+				var faces : PackedInt32Array = PackedInt32Array([0, 1])
+				set_uv_offsets(faces, get_uv_offsets(faces), Vector2(1.0, 1.0))
 				[/code]
 			</description>
 		</method>
@@ -212,7 +227,9 @@
 				Usage:
 				[code]
 				# Scale the first and second faces of CSGBrush.
-				set_uv_scale(PackedInt32Array(0, 1), get_uv_scale(PackedInt32Array(0, 1)), Vector2(2.0, 2.0))
+				var faces : PackedInt32Array = PackedInt32Array([0, 1])
+				var curr_scale : Vector2 = get_uv_scale(faces[0])
+				set_uv_scale(faces, curr_scale, Vector2(curr_scale.x * 2.0, curr_scale.y * 2.0))
 				[/code]
 				Note: The values of p_scale can never be ZERO.
 			</description>
@@ -233,9 +250,9 @@
 			- [code]vertices[/code]: [PackedVector3Array] containing the position of the triangles that make up the CSGBrush, must be divisible by 3.
 			- [code]uvs[/code]: [PackedVector2Array] containing the uv of the triangles of the CSGBrush, must be divisible by 3.
 			- [code]smooth[/code]: PackedByteArray with the smoothing groups of the faces of the CSGBrush. Currently [code]0[/code] disables the effect and any value above enables it.
-			- [code]inverted[/code]: [bool] determining the [code]invert[/code] of all the faces.
 			- [code]materials[/code]: [Array] of [Material] of the CSGBrush.
 			- [code]painted[/code]: when set to [code]true[/code], tells the engine not to rebuild the CSGBrush.
+			- [code]ngons[/code]: [PackedInt32Array] with the ngons assigned to each face.
 		</member>
 		<member name="autosmooth" type="bool" setter="set_autosmooth" getter="is_autosmooth" default="false">
 			Enables automatic smoothing. This overrides any smoothing on the CSG node and instead uses [member smoothing_angle] to calculate normals based on the angle between faces.

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -29,11 +29,25 @@
 				[b]Note:[/b] CSG mesh data updates are deferred, which means they are updated with a delay of one rendered frame. To avoid getting an empty mesh or outdated mesh data, make sure to call [code]await get_tree().process_frame[/code] before using [method bake_static_mesh] in [method Node._ready] or after changing properties on the [CSGShape3D].
 			</description>
 		</method>
+		<method name="brush_modified">
+			<return type="void" />
+			<description>
+				Forces an update of the root csg shape visuals. When used on a root shape, it rebuilds the brush.
+				This is meant to be called after [code]set_csg_brush[/code].
+			</description>
+		</method>
 		<method name="calculate_cube_map">
 			<return type="void" />
 			<param index="0" name="faces" type="PackedInt32Array" />
 			<description>
 				Generates cube map UVs for the selected faces. This is a simple unwrapping that calculates the UVs based on the direction of the face.
+			</description>
+		</method>
+		<method name="calculate_cylinder_map">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<description>
+				Generates cylinder UVs for the selected faces. This is a simple unwrapping that calculates the side UVs based on the angle from the center.
 			</description>
 		</method>
 		<method name="flip_x">

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -57,7 +57,7 @@
 				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="get_csg_brush" qualifiers="const">
+		<method name="get_csg_brush">
 			<return type="Dictionary" />
 			<description>
 				Returns the CSGBrush of the node as a [Dictionary] containing the following entries:
@@ -70,7 +70,7 @@
 				- [code]painted[/code]: when set to [code]true[/code], tells the engine not to rebuild the CSGBrush.
 			</description>
 		</method>
-		<method name="get_face_material" qualifiers="const">
+		<method name="get_face_material">
 			<return type="Material" />
 			<param index="0" name="face" type="int" />
 			<description>
@@ -84,21 +84,21 @@
 				[b]Note:[/b] CSG mesh data updates are deferred, which means they are updated with a delay of one rendered frame. To avoid getting an empty shape or outdated mesh data, make sure to call [code]await get_tree().process_frame[/code] before using [method get_meshes] in [method Node._ready] or after changing properties on the [CSGShape3D].
 			</description>
 		</method>
-		<method name="get_uv_offsets" qualifiers="const">
+		<method name="get_uv_offsets">
 			<return type="Vector2" />
 			<param index="0" name="face" type="int" />
 			<description>
 				Returns the calculated offset of the UVs of the [param face] of the CSGBrush.
 			</description>
 		</method>
-		<method name="get_uv_scale" qualifiers="const">
+		<method name="get_uv_scale">
 			<return type="Vector2" />
 			<param index="0" name="face" type="int" />
 			<description>
 				Returns the calculated scale of the UVs of the [param face] of the CSGBrush.
 			</description>
 		</method>
-		<method name="get_vertices" qualifiers="const">
+		<method name="get_vertices">
 			<return type="PackedVector3Array" />
 			<description>
 				Returns a [PackedVector3Array] with the positions of the vertices of the CSGBrush. This method ignores duplicated positions and is intended to be used with [method set_vertex_position].

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -122,7 +122,7 @@
 			<param index="1" name="size" type="Vector3" />
 			<description>
 				Resizes the CSGBrush from [param prev_size] to [param size].
-				For a [CSGBox3D], [param prev_size] would be the [code]size[/code] property, and [param size] the new dimensions.
+				For a [CSGBox3D], [param prev_size] would be the size property, and [param size] the new dimensions.
 				Note: [param size] and [param prev_size] must never have a value equal or lower than [code]0[/code].
 			</description>
 		</method>

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -238,16 +238,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="_csg_brush" type="Dictionary" setter="set_csg_brush" getter="get_csg_brush" default="{ painted : false }">
-			The CSGBrush of the node as a [Dictionary] containing the following entries:
-			- [code]material_id[/code]: PackedByteArray with the id of the material assigned to each face. See [code]materials[/code].
-			- [code]vertices[/code]: [PackedVector3Array] containing the position of the triangles that make up the CSGBrush, must be divisible by 3.
-			- [code]uvs[/code]: [PackedVector2Array] containing the uv of the triangles of the CSGBrush, must be divisible by 3.
-			- [code]smooth[/code]: PackedByteArray with the smoothing groups of the faces of the CSGBrush. Currently [code]0[/code] disables the effect and any value above enables it.
-			- [code]materials[/code]: [Array] of [Material] of the CSGBrush.
-			- [code]painted[/code]: when set to [code]true[/code], tells the engine not to rebuild the CSGBrush.
-			- [code]ngons[/code]: [PackedInt32Array] with the ngons assigned to each face.
-		</member>
 		<member name="autosmooth" type="bool" setter="set_autosmooth" getter="is_autosmooth" default="false">
 			Enables automatic smoothing. This overrides any smoothing on the CSG node and instead uses [member smoothing_angle] to calculate normals based on the angle between faces.
 			Children of a [CSGCombiner3D] node will be treated as a single mesh.

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -29,6 +29,13 @@
 				[b]Note:[/b] CSG mesh data updates are deferred, which means they are updated with a delay of one rendered frame. To avoid getting an empty mesh or outdated mesh data, make sure to call [code]await get_tree().process_frame[/code] before using [method bake_static_mesh] in [method Node._ready] or after changing properties on the [CSGShape3D].
 			</description>
 		</method>
+		<method name="calculate_cube_map">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<description>
+				Generates cube map UVs for the selected faces. This is a simple unwrapping that calculates the UVs based on the direction of the face.
+			</description>
+		</method>
 		<method name="flip_x">
 			<return type="void" />
 			<param index="0" name="faces" type="PackedInt32Array" />
@@ -82,6 +89,13 @@
 			<description>
 				Returns an [Array] with two elements, the first is the [Transform3D] of this node and the second is the root [Mesh] of this node. Only works when this node is the root shape.
 				[b]Note:[/b] CSG mesh data updates are deferred, which means they are updated with a delay of one rendered frame. To avoid getting an empty shape or outdated mesh data, make sure to call [code]await get_tree().process_frame[/code] before using [method get_meshes] in [method Node._ready] or after changing properties on the [CSGShape3D].
+			</description>
+		</method>
+		<method name="get_selected_faces">
+			<return type="PackedVector3Array" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<description>
+				Returns the vertices used to generate the selected faces. This is intended for generating a mesh to display the selected faces in the editor.
 			</description>
 		</method>
 		<method name="get_uv_offsets">
@@ -172,9 +186,9 @@
 			<return type="void" />
 			<param index="0" name="faces" type="PackedInt32Array" />
 			<param index="1" name="prev_offset" type="Vector2" />
-			<param index="2" name="offset" type="Vector2" />
+			<param index="2" name="p_offset" type="Vector2" />
 			<description>
-				Sets the UVs of [param faces] of the CSGBrush using [param offset].
+				Sets the UVs of [param faces] of the CSGBrush using [param p_offset].
 				Usage:
 				[code]
 				# Offset the first and second faces of CSGBrush.
@@ -186,15 +200,15 @@
 			<return type="void" />
 			<param index="0" name="faces" type="PackedInt32Array" />
 			<param index="1" name="prev_scale" type="Vector2" />
-			<param index="2" name="scale" type="Vector2" />
+			<param index="2" name="p_scale" type="Vector2" />
 			<description>
-				Sets the UVs of [param faces] of the CSGBrush using [param scale].
+				Sets the UVs of [param faces] of the CSGBrush using [param p_scale].
 				Usage:
 				[code]
 				# Scale the first and second faces of CSGBrush.
 				set_uv_scale(PackedInt32Array(0, 1), get_uv_scale(PackedInt32Array(0, 1)), Vector2(2.0, 2.0))
 				[/code]
-				Note: The values of scale can never be ZERO.
+				Note: The values of p_scale can never be ZERO.
 			</description>
 		</method>
 		<method name="set_vertex_position">

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -71,6 +71,13 @@
 				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
+		<method name="get_csg_face_smooth_group">
+			<return type="int" />
+			<param index="0" name="face" type="int" />
+			<description>
+				Returns the smooth value of the face.
+			</description>
+		</method>
 		<method name="get_csg_ngon_colliders">
 			<return type="PackedVector3Array[]" />
 			<description>
@@ -131,13 +138,6 @@
 				Returns a [PackedVector3Array] with the positions of the vertices of the CSGBrush. This method ignores duplicated positions and is intended to be used with [method set_vertex_position].
 			</description>
 		</method>
-		<method name="is_csg_face_smooth">
-			<return type="bool" />
-			<param index="0" name="face" type="int" />
-			<description>
-				Returns the smooth value of the face.
-			</description>
-		</method>
 		<method name="is_root_shape" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -186,12 +186,12 @@
 				Based on [param value], enables or disables the specified layer in the [member collision_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="set_csg_face_smooth">
+		<method name="set_csg_face_smooth_group">
 			<return type="void" />
 			<param index="0" name="faces" type="PackedInt32Array" />
-			<param index="1" name="smooth" type="bool" />
+			<param index="1" name="smooth" type="int" />
 			<description>
-				Sets the faces smoothing.
+				Sets the faces smoothing. A value of 0 will make the face flat while any value above will make it smooth. Faces of different brushes with the same smooth group will blend together.
 			</description>
 		</method>
 		<method name="set_face_material">

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -64,17 +64,16 @@
 				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="get_csg_brush">
-			<return type="Dictionary" />
+		<method name="get_csg_faces_anchor_points">
+			<return type="PackedVector3Array" />
 			<description>
-				Returns the CSGBrush of the node as a [Dictionary] containing the following entries:
-				- [code]material_id[/code]: PackedByteArray with the id of the material assigned to each face. See [code]materials[/code].
-				- [code]vertices[/code]: [PackedVector3Array] containing the position of the triangles that make up the CSGBrush, must be divisible by 3.
-				- [code]uvs[/code]: [PackedVector2Array] containing the uv of the triangles of the CSGBrush, must be divisible by 3.
-				- [code]smooth[/code]: PackedByteArray with the smoothing groups of the faces of the CSGBrush. Currently [code]0[/code] disables the effect and any value above enables it.
-				- [code]inverted[/code]: [bool] determining the [code]invert[/code] of all the faces.
-				- [code]materials[/code]: [Array] of [Material] of the CSGBrush.
-				- [code]painted[/code]: when set to [code]true[/code], tells the engine not to rebuild the CSGBrush.
+				Returns the center of each face for displaying anchors.
+			</description>
+		</method>
+		<method name="get_csg_num_faces">
+			<return type="int" />
+			<description>
+				Returns the number of faces of the CSGBrush.
 			</description>
 		</method>
 		<method name="get_face_material">
@@ -116,6 +115,13 @@
 			<return type="PackedVector3Array" />
 			<description>
 				Returns a [PackedVector3Array] with the positions of the vertices of the CSGBrush. This method ignores duplicated positions and is intended to be used with [method set_vertex_position].
+			</description>
+		</method>
+		<method name="is_csg_face_smooth">
+			<return type="bool" />
+			<param index="0" name="face" type="int" />
+			<description>
+				Returns the smooth value of the face.
 			</description>
 		</method>
 		<method name="is_root_shape" qualifiers="const">
@@ -166,12 +172,12 @@
 				Based on [param value], enables or disables the specified layer in the [member collision_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="set_csg_brush">
+		<method name="set_csg_face_smooth">
 			<return type="void" />
-			<param index="0" name="csg_brush" type="Dictionary" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<param index="1" name="smooth" type="bool" />
 			<description>
-				Can be used to manually set the CSGBrush.
-				See [method get_csg_brush]
+				Sets the faces smoothing.
 			</description>
 		</method>
 		<method name="set_face_material">
@@ -221,6 +227,16 @@
 		</method>
 	</methods>
 	<members>
+		<member name="_csg_brush" type="Dictionary" setter="set_csg_brush" getter="get_csg_brush" default="{ painted : false }">
+			The CSGBrush of the node as a [Dictionary] containing the following entries:
+			- [code]material_id[/code]: PackedByteArray with the id of the material assigned to each face. See [code]materials[/code].
+			- [code]vertices[/code]: [PackedVector3Array] containing the position of the triangles that make up the CSGBrush, must be divisible by 3.
+			- [code]uvs[/code]: [PackedVector2Array] containing the uv of the triangles of the CSGBrush, must be divisible by 3.
+			- [code]smooth[/code]: PackedByteArray with the smoothing groups of the faces of the CSGBrush. Currently [code]0[/code] disables the effect and any value above enables it.
+			- [code]inverted[/code]: [bool] determining the [code]invert[/code] of all the faces.
+			- [code]materials[/code]: [Array] of [Material] of the CSGBrush.
+			- [code]painted[/code]: when set to [code]true[/code], tells the engine not to rebuild the CSGBrush.
+		</member>
 		<member name="autosmooth" type="bool" setter="set_autosmooth" getter="is_autosmooth" default="false">
 			Enables automatic smoothing. This overrides any smoothing on the CSG node and instead uses [member smoothing_angle] to calculate normals based on the angle between faces.
 			Children of a [CSGCombiner3D] node will be treated as a single mesh.

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -164,7 +164,10 @@ void CSGShapeEditor::_rebuild_brush() {
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	ur->create_action(TTR("Rebuild CSG Brush"));
 	ur->add_do_method(node, "rebuild_brush");
-	ur->add_undo_method(node, "set_csg_brush", node->get_csg_brush());
+	if (Object::cast_to<CSGPrimitive3D>(node)) {
+		CSGPrimitive3D *s = Object::cast_to<CSGPrimitive3D>(node);
+		ur->add_undo_method(node, "set_csg_brush", s->get_csg_brush());
+	}
 	ur->commit_action();
 }
 

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -48,6 +48,7 @@ void CSGShapeEditor::_node_removed(Node *p_node) {
 	if (p_node == node) {
 		node = nullptr;
 		options->hide();
+		rebuild_csg->hide();
 	}
 }
 
@@ -55,8 +56,10 @@ void CSGShapeEditor::edit(CSGShape3D *p_csg_shape) {
 	node = p_csg_shape;
 	if (node) {
 		options->show();
+		rebuild_csg->show();
 	} else {
 		options->hide();
+		rebuild_csg->hide();
 	}
 }
 
@@ -179,7 +182,6 @@ CSGShapeEditor::CSGShapeEditor() {
 	rebuild_csg->hide();
 	rebuild_csg->set_text(TTR("REBUILD"));
 	rebuild_csg->set_flat(false);
-	rebuild_csg->set_theme_type_variation("FlatMenuButton");
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(rebuild_csg);
 	rebuild_csg->connect(SceneStringName(pressed), callable_mp(this, &CSGShapeEditor::_rebuild_brush));
 }

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -161,7 +161,11 @@ void CSGShapeEditor::_create_baked_collision_shape() {
 
 void CSGShapeEditor::_rebuild_brush() {
 	node->rebuild_brush();
-	// TODO Undo, Redo, Etc.
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+	ur->create_action(TTR("Rebuild CSG Brush"));
+	ur->add_do_method(node, "rebuild_brush");
+	ur->add_undo_method(node, "set_csg_brush", node->get_csg_brush());
+	ur->commit_action();
 }
 
 CSGShapeEditor::CSGShapeEditor() {
@@ -181,7 +185,6 @@ CSGShapeEditor::CSGShapeEditor() {
 	err_dialog = memnew(AcceptDialog);
 	add_child(err_dialog);
 
-	// TODO check.
 	rebuild_csg = memnew(Button);
 	rebuild_csg->hide();
 	rebuild_csg->set_text(TTR("REBUILD"));
@@ -409,16 +412,25 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	Vector<Vector3> lines;
-	lines.resize(faces.size() * 2);
-	{
-		const Vector3 *r = faces.ptr();
+	bool skip = cs->is_root_shape();
+	if (!skip) {
+		lines = cs->get_all_ngon_lines();
+		if (lines.is_empty()) {
+			skip = true;
+		}
+	}
+	if (skip) {
+		lines.resize(faces.size() * 2);
+		{
+			const Vector3 *r = faces.ptr();
 
-		for (int i = 0; i < lines.size(); i += 6) {
-			int f = i / 6;
-			for (int j = 0; j < 3; j++) {
-				int j_n = (j + 1) % 3;
-				lines.write[i + j * 2 + 0] = r[f * 3 + j];
-				lines.write[i + j * 2 + 1] = r[f * 3 + j_n];
+			for (int i = 0; i < lines.size(); i += 6) {
+				int f = i / 6;
+				for (int j = 0; j < 3; j++) {
+					int j_n = (j + 1) % 3;
+					lines.write[i + j * 2 + 0] = r[f * 3 + j];
+					lines.write[i + j * 2 + 1] = r[f * 3 + j_n];
+				}
 			}
 		}
 	}

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -49,6 +49,7 @@ void CSGShapeEditor::_node_removed(Node *p_node) {
 		node = nullptr;
 		options->hide();
 		rebuild_csg->hide();
+		cubemap_uvs->hide();
 	}
 }
 
@@ -57,13 +58,16 @@ void CSGShapeEditor::edit(CSGShape3D *p_csg_shape) {
 	if (node) {
 		if (node->is_root_shape()) {
 			options->show();
+			cubemap_uvs->hide();
 		} else {
 			options->hide();
+			cubemap_uvs->show();
 		}
 		rebuild_csg->show();
 	} else {
 		options->hide();
 		rebuild_csg->hide();
+		cubemap_uvs->hide();
 	}
 }
 
@@ -160,11 +164,21 @@ void CSGShapeEditor::_create_baked_collision_shape() {
 }
 
 void CSGShapeEditor::_rebuild_brush() {
-	node->rebuild_brush();
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+	Dictionary dict = node->get_csg_brush();
 	ur->create_action(TTR("Rebuild CSG Brush"));
 	ur->add_do_method(node, "rebuild_brush");
-	ur->add_undo_method(node, "set_csg_brush", node->get_csg_brush());
+	ur->add_undo_method(node, "set_csg_brush", dict);
+	ur->commit_action();
+}
+
+void CSGShapeEditor::_makecubeuv() {
+	// This is just too practical to not have it as a button.
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+	Dictionary dict = node->get_csg_brush();
+	ur->create_action(TTR("Make Cube"));
+	ur->add_do_method(node, "calculate_cube_map", node->get_all_csg_faces());
+	ur->add_undo_method(node, "set_csg_brush", dict);
 	ur->commit_action();
 }
 
@@ -191,6 +205,13 @@ CSGShapeEditor::CSGShapeEditor() {
 	rebuild_csg->set_flat(false);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(rebuild_csg);
 	rebuild_csg->connect(SceneStringName(pressed), callable_mp(this, &CSGShapeEditor::_rebuild_brush));
+
+	cubemap_uvs = memnew(Button);
+	cubemap_uvs->hide();
+	cubemap_uvs->set_text(TTR("Make cube uv"));
+	cubemap_uvs->set_flat(false);
+	Node3DEditor::get_singleton()->add_control_to_menu_panel(cubemap_uvs);
+	cubemap_uvs->connect(SceneStringName(pressed), callable_mp(this, &CSGShapeEditor::_makecubeuv));
 }
 
 ///////////
@@ -450,7 +471,7 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 				for (int j = 0; j < local_edges.size() / 2; j++) {
 					for (int k = j + 1; k < local_edges.size() / 2; k++) {
 						// TODO Simplify.
-						bool comp_edges = (local_edges[j * 2] == local_edges[k * 2] && local_edges[j * 2 + 1] == local_edges[k * 2 + 1]) && (local_edges[j * 2] == local_edges[k * 2 + 1] && local_edges[j * 2 + 1] == local_edges[k * 2]);
+						bool comp_edges = (local_edges[j * 2].is_equal_approx(local_edges[k * 2]) && local_edges[j * 2 + 1].is_equal_approx(local_edges[k * 2 + 1])) && (local_edges[j * 2].is_equal_approx(local_edges[k * 2 + 1]) && local_edges[j * 2 + 1].is_equal_approx(local_edges[k * 2]));
 						if (!comp_edges) {
 							temp_edges.push_back(local_edges[j * 2]);
 							temp_edges.push_back(local_edges[j * 2 + 1]);

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -164,10 +164,7 @@ void CSGShapeEditor::_rebuild_brush() {
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	ur->create_action(TTR("Rebuild CSG Brush"));
 	ur->add_do_method(node, "rebuild_brush");
-	if (Object::cast_to<CSGPrimitive3D>(node)) {
-		CSGPrimitive3D *s = Object::cast_to<CSGPrimitive3D>(node);
-		ur->add_undo_method(node, "set_csg_brush", s->get_csg_brush());
-	}
+	ur->add_undo_method(node, "set_csg_brush", node->get_csg_brush());
 	ur->commit_action();
 }
 

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -55,13 +55,12 @@ void CSGShapeEditor::_node_removed(Node *p_node) {
 void CSGShapeEditor::edit(CSGShape3D *p_csg_shape) {
 	node = p_csg_shape;
 	if (node) {
-		options->show();
-		rebuild_csg->show();
 		if (node->is_root_shape()) {
-			options->set_disabled(false);
+			options->show();
 		} else {
-			options->set_disabled(true);
+			options->hide();
 		}
+		rebuild_csg->show();
 	} else {
 		options->hide();
 		rebuild_csg->hide();
@@ -512,7 +511,7 @@ void EditorPluginCSG::edit(Object *p_object) {
 
 bool EditorPluginCSG::handles(Object *p_object) const {
 	CSGShape3D *csg_shape = Object::cast_to<CSGShape3D>(p_object);
-	return csg_shape && csg_shape->is_root_shape();
+	return csg_shape != nullptr;
 }
 
 EditorPluginCSG::EditorPluginCSG() {

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -55,7 +55,7 @@ void CSGShapeEditor::_node_removed(Node *p_node) {
 void CSGShapeEditor::edit(CSGShape3D *p_csg_shape) {
 	node = p_csg_shape;
 	if (node) {
-		options->show()
+		options->show();
 		rebuild_csg->show();
 		if (node->is_root_shape()) {
 			options->set_disabled(false);

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -50,6 +50,7 @@ void CSGShapeEditor::_node_removed(Node *p_node) {
 		options->hide();
 		rebuild_csg->hide();
 		cubemap_uvs->hide();
+		cylinder_uvs->hide();
 	}
 }
 
@@ -59,15 +60,18 @@ void CSGShapeEditor::edit(CSGShape3D *p_csg_shape) {
 		if (node->is_root_shape()) {
 			options->show();
 			cubemap_uvs->hide();
+			cylinder_uvs->hide();
 		} else {
 			options->hide();
 			cubemap_uvs->show();
+			cylinder_uvs->show();
 		}
 		rebuild_csg->show();
 	} else {
 		options->hide();
 		rebuild_csg->hide();
 		cubemap_uvs->hide();
+		cylinder_uvs->hide();
 	}
 }
 
@@ -169,6 +173,7 @@ void CSGShapeEditor::_rebuild_brush() {
 	ur->create_action(TTR("Rebuild CSG Brush"));
 	ur->add_do_method(node, "rebuild_brush");
 	ur->add_undo_method(node, "set_csg_brush", dict);
+	ur->add_undo_method(node, "brush_modified");
 	ur->commit_action();
 }
 
@@ -179,6 +184,17 @@ void CSGShapeEditor::_makecubeuv() {
 	ur->create_action(TTR("Make Cube"));
 	ur->add_do_method(node, "calculate_cube_map", node->get_all_csg_faces());
 	ur->add_undo_method(node, "set_csg_brush", dict);
+	ur->add_undo_method(node, "brush_modified");
+	ur->commit_action();
+}
+
+void CSGShapeEditor::_makecylinderuv() {
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+	Dictionary dict = node->get_csg_brush();
+	ur->create_action(TTR("Make Cylinder"));
+	ur->add_do_method(node, "calculate_cylinder_map", node->get_all_csg_faces());
+	ur->add_undo_method(node, "set_csg_brush", dict);
+	ur->add_undo_method(node, "brush_modified");
 	ur->commit_action();
 }
 
@@ -212,6 +228,13 @@ CSGShapeEditor::CSGShapeEditor() {
 	cubemap_uvs->set_flat(false);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(cubemap_uvs);
 	cubemap_uvs->connect(SceneStringName(pressed), callable_mp(this, &CSGShapeEditor::_makecubeuv));
+
+	cylinder_uvs = memnew(Button);
+	cylinder_uvs->hide();
+	cylinder_uvs->set_text(TTR("Make cylinder uv"));
+	cylinder_uvs->set_flat(false);
+	Node3DEditor::get_singleton()->add_control_to_menu_panel(cylinder_uvs);
+	cylinder_uvs->connect(SceneStringName(pressed), callable_mp(this, &CSGShapeEditor::_makecylinderuv));
 }
 
 ///////////
@@ -439,48 +462,31 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		if (local_csg_faces.is_empty()) {
 			skip = true;
 		}
-		// TODO Optimize.
 		Vector<Vector3> temp_edges;
 		for (int i = 0; i < local_csg_faces.size(); i++) {
-			Vector<Vector3> local_edges;
 			Vector<Vector3> curr_ngon = local_csg_faces[i];
 			// Convert to lines.
 			if (curr_ngon.size() == 6) {
 				// Quad.
-				local_edges.resize(8);
-				local_edges.write[0] = curr_ngon[0];
-				local_edges.write[1] = curr_ngon[1];
-				local_edges.write[2] = curr_ngon[1];
-				local_edges.write[3] = curr_ngon[2];
-				local_edges.write[4] = curr_ngon[3];
-				local_edges.write[5] = curr_ngon[4];
-				local_edges.write[6] = curr_ngon[4];
-				local_edges.write[7] = curr_ngon[5];
+				temp_edges.push_back(curr_ngon[0]);
+				temp_edges.push_back(curr_ngon[1]);
+				temp_edges.push_back(curr_ngon[1]);
+				temp_edges.push_back(curr_ngon[2]);
+				temp_edges.push_back(curr_ngon[3]);
+				temp_edges.push_back(curr_ngon[4]);
+				temp_edges.push_back(curr_ngon[4]);
+				temp_edges.push_back(curr_ngon[5]);
+			} else if (curr_ngon.size() > 6) {
+				// Since the only way to generate Ngons is through CSG building and they are always surrounded by quads, we just skip the ngons.
+				continue;
 			} else {
-				// Tri and Ngon.
+				// Tris.
 				for (int j = 0; j < curr_ngon.size() / 3; j++) {
 					for (int k = 0; k < 3; k++) {
 						int k_n = (k + 1) % 3;
-						local_edges.push_back(curr_ngon[j * 3 + k]);
-						local_edges.push_back(curr_ngon[j * 3 + k_n]);
+						temp_edges.push_back(curr_ngon[j * 3 + k]);
+						temp_edges.push_back(curr_ngon[j * 3 + k_n]);
 					}
-				}
-			}
-			if (curr_ngon.size() > 6) {
-				// Remove doubles inside ngon.
-				for (int j = 0; j < local_edges.size() / 2; j++) {
-					for (int k = j + 1; k < local_edges.size() / 2; k++) {
-						// TODO Simplify.
-						bool comp_edges = (local_edges[j * 2].is_equal_approx(local_edges[k * 2]) && local_edges[j * 2 + 1].is_equal_approx(local_edges[k * 2 + 1])) && (local_edges[j * 2].is_equal_approx(local_edges[k * 2 + 1]) && local_edges[j * 2 + 1].is_equal_approx(local_edges[k * 2]));
-						if (!comp_edges) {
-							temp_edges.push_back(local_edges[j * 2]);
-							temp_edges.push_back(local_edges[j * 2 + 1]);
-						}
-					}
-				}
-			} else {
-				for (int j = 0; j < local_edges.size(); j++) {
-					temp_edges.push_back(local_edges[j]);
 				}
 			}
 		}

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -414,7 +414,70 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	Vector<Vector3> lines;
 	bool skip = cs->is_root_shape();
 	if (!skip) {
-		lines = cs->get_all_ngon_lines();
+		TypedArray<Vector<Vector3>> local_csg_faces = cs->get_csg_ngon_colliders();
+		if (local_csg_faces.is_empty()) {
+			skip = true;
+		}
+		// TODO Optimize.
+		Vector<Vector3> temp_edges;
+		for (int i = 0; i < local_csg_faces.size(); i++) {
+			Vector<Vector3> local_edges;
+			Vector<Vector3> curr_ngon = local_csg_faces[i];
+			// Convert to lines.
+			if (curr_ngon.size() == 6) {
+				// Quad.
+				local_edges.resize(8);
+				local_edges.write[0] = curr_ngon[0];
+				local_edges.write[1] = curr_ngon[1];
+				local_edges.write[2] = curr_ngon[1];
+				local_edges.write[3] = curr_ngon[2];
+				local_edges.write[4] = curr_ngon[3];
+				local_edges.write[5] = curr_ngon[4];
+				local_edges.write[6] = curr_ngon[4];
+				local_edges.write[7] = curr_ngon[5];
+			} else {
+				// Tri and Ngon.
+				for (int j = 0; j < curr_ngon.size() / 3; j++) {
+					for (int k = 0; k < 3; k++) {
+						int k_n = (k + 1) % 3;
+						local_edges.push_back(curr_ngon[j * 3 + k]);
+						local_edges.push_back(curr_ngon[j * 3 + k_n]);
+					}
+				}
+			}
+			if (curr_ngon.size() > 6) {
+				// Remove doubles inside ngon.
+				for (int j = 0; j < local_edges.size() / 2; j++) {
+					for (int k = j + 1; k < local_edges.size() / 2; k++) {
+						// TODO Simplify.
+						bool comp_edges = (local_edges[j * 2] == local_edges[k * 2] && local_edges[j * 2 + 1] == local_edges[k * 2 + 1]) && (local_edges[j * 2] == local_edges[k * 2 + 1] && local_edges[j * 2 + 1] == local_edges[k * 2]);
+						if (!comp_edges) {
+							temp_edges.push_back(local_edges[j * 2]);
+							temp_edges.push_back(local_edges[j * 2 + 1]);
+						}
+					}
+				}
+			} else {
+				for (int j = 0; j < local_edges.size(); j++) {
+					temp_edges.push_back(local_edges[j]);
+				}
+			}
+		}
+		// Remove duplicated lines.
+		for (int i = 0; i < temp_edges.size() / 2; i++) {
+			bool found_edge = false;
+			for (int j = 0; j < lines.size() / 2; j++) {
+				if (temp_edges[i * 2].is_equal_aprox(lines[j * 2]) && temp_edges[i * 2 + 1].is_equal_aprox(lines[j * 2 + 1]) && temp_edges[i * 2].is_equal_aprox(lines[j * 2 + 1]) && temp_edges[i * 2 + 1].is_equal_aprox(lines[j * 2])) {
+					found_edge = true;
+					break;
+				}
+			}
+
+			if (!found_edge) {
+				lines.push_back(temp_edges[i * 2]);
+				lines.push_back(temp_edges[i * 2 + 1]);
+			}
+		}
 		if (lines.is_empty()) {
 			skip = true;
 		}

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -55,12 +55,13 @@ void CSGShapeEditor::_node_removed(Node *p_node) {
 void CSGShapeEditor::edit(CSGShape3D *p_csg_shape) {
 	node = p_csg_shape;
 	if (node) {
-		if (node->is_root_shape()) {
-			options->show();
-		} else {
-			options->hide();
-		}
+		options->show()
 		rebuild_csg->show();
+		if (node->is_root_shape()) {
+			options->set_disabled(false);
+		} else {
+			options->set_disabled(true);
+		}
 	} else {
 		options->hide();
 		rebuild_csg->hide();

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -467,7 +467,7 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		for (int i = 0; i < temp_edges.size() / 2; i++) {
 			bool found_edge = false;
 			for (int j = 0; j < lines.size() / 2; j++) {
-				if (temp_edges[i * 2].is_equal_aprox(lines[j * 2]) && temp_edges[i * 2 + 1].is_equal_aprox(lines[j * 2 + 1]) && temp_edges[i * 2].is_equal_aprox(lines[j * 2 + 1]) && temp_edges[i * 2 + 1].is_equal_aprox(lines[j * 2])) {
+				if (temp_edges[i * 2].is_equal_approx(lines[j * 2]) && temp_edges[i * 2 + 1].is_equal_approx(lines[j * 2 + 1]) && temp_edges[i * 2].is_equal_approx(lines[j * 2 + 1]) && temp_edges[i * 2 + 1].is_equal_approx(lines[j * 2])) {
 					found_edge = true;
 					break;
 				}

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -55,7 +55,11 @@ void CSGShapeEditor::_node_removed(Node *p_node) {
 void CSGShapeEditor::edit(CSGShape3D *p_csg_shape) {
 	node = p_csg_shape;
 	if (node) {
-		options->show();
+		if (node->is_root_shape()) {
+			options->show();
+		} else {
+			options->hide();
+		}
 		rebuild_csg->show();
 	} else {
 		options->hide();
@@ -502,11 +506,7 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 void EditorPluginCSG::edit(Object *p_object) {
 	CSGShape3D *csg_shape = Object::cast_to<CSGShape3D>(p_object);
-	if (csg_shape && csg_shape->is_root_shape()) {
-		csg_shape_editor->edit(csg_shape);
-	} else {
-		csg_shape_editor->edit(nullptr);
-	}
+	csg_shape_editor->edit(csg_shape);
 }
 
 bool EditorPluginCSG::handles(Object *p_object) const {

--- a/modules/csg/editor/csg_gizmos.h
+++ b/modules/csg/editor/csg_gizmos.h
@@ -72,6 +72,7 @@ class CSGShapeEditor : public Control {
 	CSGShape3D *node = nullptr;
 	MenuButton *options = nullptr;
 	Button *rebuild_csg = nullptr;
+	Button *cubemap_uvs = nullptr;
 	AcceptDialog *err_dialog = nullptr;
 
 	void _menu_option(int p_option);
@@ -80,6 +81,7 @@ class CSGShapeEditor : public Control {
 	void _create_baked_collision_shape();
 
 	void _rebuild_brush();
+	void _makecubeuv();
 
 protected:
 	void _node_removed(Node *p_node);

--- a/modules/csg/editor/csg_gizmos.h
+++ b/modules/csg/editor/csg_gizmos.h
@@ -73,6 +73,7 @@ class CSGShapeEditor : public Control {
 	MenuButton *options = nullptr;
 	Button *rebuild_csg = nullptr;
 	Button *cubemap_uvs = nullptr;
+	Button *cylinder_uvs = nullptr;
 	AcceptDialog *err_dialog = nullptr;
 
 	void _menu_option(int p_option);
@@ -82,6 +83,7 @@ class CSGShapeEditor : public Control {
 
 	void _rebuild_brush();
 	void _makecubeuv();
+	void _makecylinderuv();
 
 protected:
 	void _node_removed(Node *p_node);


### PR DESCRIPTION
 - fix editor button
 - add _make_painted() method to replace _make_dirty() across the code. When passed with a parameter (`_make_painted(true)`), it sets the node as **painted**, meaning it is saved to disk and doesn't automatically rebuild anymore. _make_painted() calls _make_dirty() when used on the root shape.
 - add `rebuild_brush()` method. rebuild_brush() is called when pressing the REBUILD button, it gets the brush to !painted and forces a rebuild of the CSGBrush through `_make_dirty()`. After doing changes to something like the `sides` property of CSGCylinder, if it's painted it won't update automatically anymore, the REBUILD button must be pressed to apply changes and clear any customization of the faces or vertices.
 - When calling `_get_brush`, the brush is always returned. Manifold operations only work on the root shape. Added a recursive method to get ALL children, the manifold operations must then be applied in order.
 - `get_csg_brush` and `set_csg_brush` are used to store the CSGBrush as a dictionary. it should only save "painted" brushes. This means individual CSG nodes cannot have their brushes edited.
 - invert of brush is saved as a single variable. The system is not designed to save modified shapes, only base brushes.
 - added set and get uv_offsets for offsetting uvs of CSGBrush. Also set and get uv_scale. ~These need testing~ these work but the godot export seems to make constant calls which cause the engine to crash.
 - added flip_x and flip_y for mirroring uvs of CSGBrush. ~these need testing~ works.
 - Added `resize_brush` method for resizing brush without rebuilding. I tried adding more methods like this, but most times, changes to the CSG node will force a rebuild and loose all changes. CSGBox should have no problems, as its only property changes size.
 - `set_csg_flat` toggles between all faces of CSG being flat or smooth. This is not used on Cylinder. name could be changed.
 - set_face_material can be used to change material.
 - added get_vertices() for a vertex editor. It doesn't return duplicated vertices. It's not needed for this PR but it's very simple.
 - added set_vertex_position(), it takes a vertex position and changes it for all vertices that share that position.
 - added a `get_selected_faces` method to return the vertices of the selected faces. This is intended to be used to display selected faces when creating a face editor.
 - added VERY simple cubemap unwrapping for selected faces. ~Needs testing~ seems to work.
 - added ngons
 - exposed most of these to gdscript, but the idea is to create a built-in editor and not an addon.
needs A LOT of testing.